### PR TITLE
Remove before funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ import { Test, expect } from "vulcan/lib.sol";
 
 contract TestSomething is Test {
 
-    function before() internal override { } // Optional
-
-    function beforeEach() internal override { } // Optional
-
     function testSomething() external {
         expect(true).toBeTrue();
         expect(true).toEqual(true);

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -10,22 +10,9 @@ contract Test {
 
     bool public IS_TEST = true;
 
-    bool first = false;
-
-    function setUp() external {
+    constructor() {
         vulcan.init();
-
-        if (!first) {
-            first = true;
-            before();
-        }
-
-        beforeEach();
     }
-
-    function before() internal virtual {}
-
-    function beforeEach() internal virtual {}
 
     function failed() public view returns (bool) {
         return vulcan.failed();

--- a/test/ExampleTest.sol
+++ b/test/ExampleTest.sol
@@ -7,10 +7,6 @@ contract ExampleTest is Test {
     using vulcan for *;
     using accounts for *;
 
-    function beforeEach() internal view override {
-        // console.log("before each");
-    }
-
     function testSetBlockNumber() external {
         uint256 blockNumber = block.number + 1000;
         ctx.setBlockNumber(blockNumber);


### PR DESCRIPTION
Closes #66 

Because of the way foundry tests are ran, having these functions don't make sense (except maybe from a naming perspective). So I'm removing them for now.