### PR TITLE
fix: remove selfdestruct

### DIFF
--- a/src/Watcher.sol
+++ b/src/Watcher.sol
@@ -195,7 +195,10 @@ contract Watcher {
     function stop() external {
         address target = watchers.targetAddress(address(this));
         accounts.setCode(target, implementation.code);
-        selfdestruct(payable(address(0)));
+
+        shouldCaptureReverts = false;
+        implementation = address(0);
+        delete _calls;
     }
 
     /// @dev Sets the address of the `implementation` contract.

--- a/test/Watcher.t.sol
+++ b/test/Watcher.t.sol
@@ -107,4 +107,22 @@ contract WatcherTest is Test {
         expect(t.calls()[1].success).toBeTrue();
         expect(t.calls()[1].returnData).toEqual(abi.encodePacked(i));
     }
+
+    function testItRestoresTheOriginalStateAfterStop() external {
+        WatcherTarget target = new WatcherTarget();
+        address t = address(target);
+
+        bytes32 originalCode = keccak256(t.code);
+
+        watchers.watch(t);
+
+        target.success(0);
+
+        expect(t.calls().length).toEqual(1);
+
+        t.stopWatcher();
+
+        expect(t.calls().length).toEqual(0);
+        expect(keccak256(t.code)).toEqual(originalCode);
+    }
 }


### PR DESCRIPTION
Removes the `selfdestruct` call on the `Watcher` contract.

Closes #86 