### PR TITLE
Add huffc support

### DIFF
--- a/src/Huff.sol
+++ b/src/Huff.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13 <0.9.0;
+
+import "./Command.sol";
+import "./Strings.sol";
+
+struct Huffc {
+    string compilerPath;
+    string filePath;
+    string outputPath;
+    string mainName;
+    string constructorName;
+    bool onlyRuntime;
+    string[] constantOverrides;
+}
+
+library huff {
+    using strings for bytes32;
+    using huff for Huffc;
+
+    function create() internal pure returns (Huffc memory) {
+        return Huffc({
+            compilerPath: "huffc",
+            filePath: "",
+            outputPath: "",
+            mainName: "",
+            constructorName: "",
+            onlyRuntime: false,
+            constantOverrides: new string[](0)
+        });
+    }
+
+    function compile(Huffc memory self) internal returns (bytes memory) {
+        bytes memory output = self.toCommand().run();
+        // TODO: add error handling
+        return output;
+    }
+
+    function toCommand(Huffc memory self) internal pure returns (Command memory) {
+        Command memory command = commands.create(self.compilerPath);
+        require(bytes(self.filePath).length > 0, "self.filePath not set");
+
+        if (bytes(self.outputPath).length > 0) command = command.args(["-ao", self.outputPath]);
+        if (bytes(self.mainName).length > 0) command = command.args(["-m", self.mainName]);
+        if (bytes(self.constructorName).length > 0) command = command.args(["-l", self.constructorName]);
+        if (self.onlyRuntime) command = command.args(["-r"]);
+        if (self.constantOverrides.length > 0) {
+            string memory overrides = "";
+            for (uint256 i; i < self.constantOverrides.length; i++) {
+                overrides = string.concat(overrides, (i == 0 ? '' : ' '), self.constantOverrides[i]);
+            }
+            command = command.args(["-c", overrides]);
+        }
+
+        // MUST be last
+        command = command.args(["-b", self.filePath]);
+        return command;
+    }
+
+    function setCompilerPath(Huffc memory self, string memory compilerPath) internal pure returns (Huffc memory) {
+        self.compilerPath = compilerPath;
+        return self;
+    }
+
+    function setFilePath(Huffc memory self, string memory filePath) internal pure returns (Huffc memory) {
+        self.filePath = filePath;
+        return self;
+    }
+
+    function setOutputPath(Huffc memory self, string memory outputPath) internal pure returns (Huffc memory) {
+        self.outputPath = outputPath;
+        return self;
+    }
+
+    function setMainName(Huffc memory self, string memory mainName) internal pure returns (Huffc memory) {
+        self.mainName = mainName;
+        return self;
+    }
+
+    function setConstructorName(Huffc memory self, string memory constructorName) internal pure returns (Huffc memory) {
+        self.constructorName = constructorName;
+        return self;
+    }
+
+    function setOnlyRuntime(Huffc memory self, bool onlyRuntime) internal pure returns (Huffc memory) {
+        self.onlyRuntime = onlyRuntime;
+        return self;
+    }
+
+    function addConstantOverride(Huffc memory self, string memory const, bytes32 value) internal pure returns (Huffc memory) {
+        string[] memory overrides = new string[](self.constantOverrides.length + 1);
+        for (uint256 i; i < self.constantOverrides.length; i++) {
+            overrides[i] = self.constantOverrides[i];
+        }
+        overrides[overrides.length - 1] = string.concat(const, "=", value.toString());
+        self.constantOverrides = overrides;
+        return self;
+    }
+}

--- a/src/test.sol
+++ b/src/test.sol
@@ -11,6 +11,7 @@ import {events} from "./Events.sol";
 import {expect} from "./Expect.sol";
 import {forks, Fork} from "./Fork.sol";
 import {fs, FsMetadata} from "./Fs.sol";
+import {huff, Huffc} from "./Huff.sol";
 import {json, JsonObject} from "./Json.sol";
 import {strings} from "./Strings.sol";
 import {watchers, Watcher} from "./Watcher.sol";

--- a/test/Huff.t.sol
+++ b/test/Huff.t.sol
@@ -1,0 +1,40 @@
+pragma solidity >=0.8.13 <0.9.0;
+
+import {Test, expect, Command, console, huff, Huffc} from "../src/test.sol";
+
+bytes32 constant SLOT = 0x0000000000000000000000000000000000000000000000000000000000000001;
+bytes32 constant OTHER_SLOT = 0x0000000000000000000000000000000000000000000000000000000000000002;
+string constant SLOTS_AS_STRING =
+    "SLOT=0x0000000000000000000000000000000000000000000000000000000000000001 OTHER_SLOT=0x0000000000000000000000000000000000000000000000000000000000000002";
+
+contract HuffTest is Test {
+    using huff for *;
+
+    function testToCommand() external {
+        Command memory command = huff.create().setCompilerPath("diffhuff").setFilePath("./filePath.huff").setOutputPath(
+            "./outputPath.json"
+        ).setMainName("ALT_MAIN").setConstructorName("ALT_CONSTRUCTOR").setOnlyRuntime(true).addConstantOverride(
+            "SLOT", SLOT
+        ).addConstantOverride("OTHER_SLOT", OTHER_SLOT).toCommand();
+
+        expect(command.inputs.length).toEqual(12);
+        expect(command.inputs[0]).toEqual("diffhuff");
+        expect(command.inputs[1]).toEqual("-ao");
+        expect(command.inputs[2]).toEqual("./outputPath.json");
+        expect(command.inputs[3]).toEqual("-m");
+        expect(command.inputs[4]).toEqual("ALT_MAIN");
+        expect(command.inputs[5]).toEqual("-l");
+        expect(command.inputs[6]).toEqual("ALT_CONSTRUCTOR");
+        expect(command.inputs[7]).toEqual("-r");
+        expect(command.inputs[8]).toEqual("-c");
+        expect(command.inputs[9]).toEqual(SLOTS_AS_STRING);
+        expect(command.inputs[10]).toEqual("-b");
+        expect(command.inputs[11]).toEqual("./filePath.huff");
+    }
+
+    function testCompile() external {
+        expect(huff.create().setFilePath("./test/mocks/Getter.huff").compile()).toEqual(
+            hex"602e8060093d393df360003560e01c806360fe47b11461001b57636d4ce63c14610022575b6004356000555b60005460005160206000f3"
+        );
+    }
+}

--- a/test/mocks/Getter.huff
+++ b/test/mocks/Getter.huff
@@ -1,0 +1,39 @@
+#define constant SLOT = FREE_STORAGE_POINTER()
+
+#define macro SET() = takes (0) returns (0) {
+	0x04			// [value_offset]
+	calldataload		// [value]
+	[SLOT]			// [slot, value]
+	sstore			// []
+}
+
+#define macro GET() = takes (0) returns (0) {
+	[SLOT]			// [slot]
+	sload			// [value]
+	0x00			// [offset, value]
+	mload			// []
+	0x20			// [size]
+	0x00			// [offset, size]
+	return			// []
+}
+
+#define macro MAIN() = takes (0) returns (0) {
+	0x00			// [offset]
+	calldataload		// [value]
+	0xe0			// [shift, value]
+	shr			// [selector]
+	dup1			// [selector, selector]
+	0x60fe47b1		// [setselector, selector, selector]
+	eq			// [issetselector, selector]
+	set			// [jumpdest, issetselector selector]
+	jumpi			// [selector]
+	0x6d4ce63c		// [getselector, selector]
+	eq			// [isgetselector]
+	get			// [jumpdest, isgetselector]
+	jumpi			// []
+
+	set:
+		SET()
+	get:
+		GET()
+}


### PR DESCRIPTION
## Overview

Adds huff compiler support.

> NOTE: WIP

## Additions

Adds a `huff` library and `Huffc` structure with the following fields:

- `compilerPath`: path of compiler (Default: `huffc`)
- `filePath`: path of input file (Required)
- `outputPath`: path of artifacts (Optional)
- `mainName`: name of alternate `MAIN` macro (Optional)
- `constructorName`: name of alternate `CONSTRUCTOR` macro (Optional)
- `onlyRuntime`: if true, only the runtime bytecode will be returned (Default: `false`)
- `constantOverrides`: list of key value pairs in the format `"<constant_name>=<hex_literal>"`

Setting any value may be done via a `set<Field>` API and adding values to lists may be done via an `add<Field>` API.

Can be run directly via `compile` or converted to a `Command` via `toCommand` methods.

```solidity
huff.create()
    .setCompilerPath("diffhuff")
    .setFilePath("./filePath.huff")
    .setOutputPath("./outputPath.json")
    .setMainName("ALT_MAIN")
    .setConstructorName("ALT_CONSTRUCTOR")
    .setOnlyRuntime(true)
    .addConstantOverride("SLOT", SLOT)
    .addConstantOverride("OTHER_SLOT", OTHER_SLOT)
    .compile();
```

## In Progress 

1. Add documentation
2. Extend testing
3. Decide how to handle testing if tester does not have `huffc` in path
4. Generalize for other langauges