### PR TITLE
chore: replace parse with get on json

### DIFF
--- a/docs/src/reference/modules/json.md
+++ b/docs/src/reference/modules/json.md
@@ -7,19 +7,19 @@ struct JsonObject {
 }
 ```
 
-#### **`getObject(string jsonStr, string key) → (bytes abiEncodedData)`**
+#### **`get(string jsonStr, string key) → (bytes abiEncodedData)`**
 
 Parses a json object string by key and returns an ABI encoded value.
 
-#### **`getObject(string jsonStr) → (bytes abiEncodedData)`**
+#### **`get(string jsonStr) → (bytes abiEncodedData)`**
 
 Parses a json object string and returns an ABI encoded tuple.
 
-#### **`getObject(JsonObject jsonObj, string key) → (bytes abiEncodedData)`**
+#### **`get(JsonObject jsonObj, string key) → (bytes abiEncodedData)`**
 
 Parses a json object struct by key and returns an ABI encoded value.
 
-#### **`getObject(JsonObject jsonObj) → (bytes abiEncodedData)`**
+#### **`get(JsonObject jsonObj) → (bytes abiEncodedData)`**
 
 Parses a json object struct and returns an ABI encoded tuple.
 

--- a/docs/src/reference/modules/json.md
+++ b/docs/src/reference/modules/json.md
@@ -7,19 +7,19 @@ struct JsonObject {
 }
 ```
 
-#### **`get(string jsonStr, string key) → (bytes abiEncodedData)`**
+#### **`getObject(string jsonStr, string key) → (bytes abiEncodedData)`**
 
 Parses a json object string by key and returns an ABI encoded value.
 
-#### **`get(string jsonStr) → (bytes abiEncodedData)`**
+#### **`parse(string jsonStr) → (bytes abiEncodedData)`**
 
 Parses a json object string and returns an ABI encoded tuple.
 
-#### **`get(JsonObject jsonObj, string key) → (bytes abiEncodedData)`**
+#### **`getObject(JsonObject jsonObj, string key) → (bytes abiEncodedData)`**
 
 Parses a json object struct by key and returns an ABI encoded value.
 
-#### **`get(JsonObject jsonObj) → (bytes abiEncodedData)`**
+#### **`parse(JsonObject jsonObj) → (bytes abiEncodedData)`**
 
 Parses a json object struct and returns an ABI encoded tuple.
 

--- a/docs/src/reference/modules/json.md
+++ b/docs/src/reference/modules/json.md
@@ -7,75 +7,75 @@ struct JsonObject {
 }
 ```
 
-#### **`parseObject(string jsonStr, string key) → (bytes abiEncodedData)`**
+#### **`getObject(string jsonStr, string key) → (bytes abiEncodedData)`**
 
 Parses a json object string by key and returns an ABI encoded value.
 
-#### **`parseObject(string jsonStr) → (bytes abiEncodedData)`**
+#### **`getObject(string jsonStr) → (bytes abiEncodedData)`**
 
 Parses a json object string and returns an ABI encoded tuple.
 
-#### **`parseObject(JsonObject jsonObj, string key) → (bytes abiEncodedData)`**
+#### **`getObject(JsonObject jsonObj, string key) → (bytes abiEncodedData)`**
 
 Parses a json object struct by key and returns an ABI encoded value.
 
-#### **`parseObject(JsonObject jsonObj) → (bytes abiEncodedData)`**
+#### **`getObject(JsonObject jsonObj) → (bytes abiEncodedData)`**
 
 Parses a json object struct and returns an ABI encoded tuple.
 
-#### **`parseUint(string jsonStr, string key) → (uint256)`**
+#### **`getUint(string jsonStr, string key) → (uint256)`**
 
 Parses the value of the `key` contained on `jsonStr` as uint256.
 
-#### **`parseUintArray(string jsonStr, string key) → (uint256[] )`**
+#### **`getUintArray(string jsonStr, string key) → (uint256[] )`**
 
 Parses the value of the `key` contained on `jsonStr` as uint256[].
 
-#### **`parseInt(string jsonStr, string key) → (int256)`**
+#### **`getInt(string jsonStr, string key) → (int256)`**
 
 Parses the value of the `key` contained on `jsonStr` as int256.
 
-#### **`parseIntArray(string jsonStr, string key) → (int256[] )`**
+#### **`getIntArray(string jsonStr, string key) → (int256[] )`**
 
 Parses the value of the `key` contained on `jsonStr` as int256[].
 
-#### **`parseBool(string jsonStr, string key) → (bool)`**
+#### **`getBool(string jsonStr, string key) → (bool)`**
 
 Parses the value of the `key` contained on `jsonStr` as bool.
 
-#### **`parseBoolArray(string jsonStr, string key) → (bool[] )`**
+#### **`getBoolArray(string jsonStr, string key) → (bool[] )`**
 
 Parses the value of the `key` contained on `jsonStr` as bool[].
 
-#### **`parseAddress(string jsonStr, string key) → (address)`**
+#### **`getAddress(string jsonStr, string key) → (address)`**
 
 Parses the value of the `key` contained on `jsonStr` as address.
 
-#### **`parseAddressArray(string jsonStr, string key) → (address[] )`**
+#### **`getAddressArray(string jsonStr, string key) → (address[] )`**
 
 Parses the value of the `key` contained on `jsonStr` as address.
 
-#### **`parseString(string jsonStr, string key) → (string )`**
+#### **`getString(string jsonStr, string key) → (string )`**
 
 Parses the value of the `key` contained on `jsonStr` as string.
 
-#### **`parseStringArray(string jsonStr, string key) → (string[] )`**
+#### **`getStringArray(string jsonStr, string key) → (string[] )`**
 
 Parses the value of the `key` contained on `jsonStr` as string[].
 
-#### **`parseBytes(string jsonStr, string key) → (bytes )`**
+#### **`getBytes(string jsonStr, string key) → (bytes )`**
 
 Parses the value of the `key` contained on `jsonStr` as bytes.
 
-#### **`parseBytesArray(string jsonStr, string key) → (bytes[] )`**
+#### **`getBytesArray(string jsonStr, string key) → (bytes[] )`**
 
 Parses the value of the `key` contained on `jsonStr` as bytes[].
 
-#### **`parseBytes32(string jsonStr, string key) → (bytes32)`**
+#### **`getBytes32(string jsonStr, string key) → (bytes32)`**
 
 Parses the value of the `key` contained on `jsonStr` as bytes32.
 
-#### **`parseBytes32Array(string jsonStr, string key) → (bytes32[] )`**
+#### **`getBytes32Array(string jsonStr, string key) → (bytes32[] )`**
 
 Parses the value of the `key` contained on `jsonStr` as bytes32[].
 

--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -14,14 +14,14 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return abiEncodedData The ABI encoded tuple representing the value of the provided key.
-    function get(string memory jsonStr, string memory key) internal pure returns (bytes memory abiEncodedData) {
+    function getObject(string memory jsonStr, string memory key) internal pure returns (bytes memory abiEncodedData) {
         return vulcan.hevm.parseJson(jsonStr, key);
     }
 
     /// @dev Parses a json object string and returns an ABI encoded tuple.
     /// @param jsonStr The json string.
     /// @return abiEncodedData The ABI encoded tuple representing the json object.
-    function get(string memory jsonStr) internal pure returns (bytes memory abiEncodedData) {
+    function parse(string memory jsonStr) internal pure returns (bytes memory abiEncodedData) {
         return vulcan.hevm.parseJson(jsonStr);
     }
 
@@ -29,14 +29,18 @@ library json {
     /// @param jsonObj The json object struct.
     /// @param key The key from the `jsonObject` to parse.
     /// @return abiEncodedData The ABI encoded tuple representing the value of the provided key.
-    function get(JsonObject memory jsonObj, string memory key) internal pure returns (bytes memory abiEncodedData) {
+    function getObject(JsonObject memory jsonObj, string memory key)
+        internal
+        pure
+        returns (bytes memory abiEncodedData)
+    {
         return vulcan.hevm.parseJson(jsonObj.serialized, key);
     }
 
     /// @dev Parses a json object struct and returns an ABI encoded tuple.
     /// @param jsonObj The json struct.
     /// @return abiEncodedData The ABI encoded tuple representing the json object.
-    function get(JsonObject memory jsonObj) internal pure returns (bytes memory abiEncodedData) {
+    function parse(JsonObject memory jsonObj) internal pure returns (bytes memory abiEncodedData) {
         return vulcan.hevm.parseJson(jsonObj.serialized);
     }
 

--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -25,7 +25,7 @@ library json {
     /// @dev Parses a json object string and returns an ABI encoded tuple.
     /// @param jsonStr The json string.
     /// @return abiEncodedData The ABI encoded tuple representing the json object.
-    function getObject(string memory jsonStr) internal pure returns (bytes memory abiEncodedData) {
+    function get(string memory jsonStr) internal pure returns (bytes memory abiEncodedData) {
         return vulcan.hevm.parseJson(jsonStr);
     }
 
@@ -33,7 +33,7 @@ library json {
     /// @param jsonObj The json object struct.
     /// @param key The key from the `jsonObject` to parse.
     /// @return abiEncodedData The ABI encoded tuple representing the value of the provided key.
-    function getObject(JsonObject memory jsonObj, string memory key)
+    function get(JsonObject memory jsonObj, string memory key)
         internal
         pure
         returns (bytes memory abiEncodedData)
@@ -44,7 +44,7 @@ library json {
     /// @dev Parses a json object struct and returns an ABI encoded tuple.
     /// @param jsonObj The json struct.
     /// @return abiEncodedData The ABI encoded tuple representing the json object.
-    function getObject(JsonObject memory jsonObj) internal pure returns (bytes memory abiEncodedData) {
+    function get(JsonObject memory jsonObj) internal pure returns (bytes memory abiEncodedData) {
         return vulcan.hevm.parseJson(jsonObj.serialized);
     }
 

--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -14,11 +14,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return abiEncodedData The ABI encoded tuple representing the value of the provided key.
-    function get(string memory jsonStr, string memory key)
-        internal
-        pure
-        returns (bytes memory abiEncodedData)
-    {
+    function get(string memory jsonStr, string memory key) internal pure returns (bytes memory abiEncodedData) {
         return vulcan.hevm.parseJson(jsonStr, key);
     }
 
@@ -33,11 +29,7 @@ library json {
     /// @param jsonObj The json object struct.
     /// @param key The key from the `jsonObject` to parse.
     /// @return abiEncodedData The ABI encoded tuple representing the value of the provided key.
-    function get(JsonObject memory jsonObj, string memory key)
-        internal
-        pure
-        returns (bytes memory abiEncodedData)
-    {
+    function get(JsonObject memory jsonObj, string memory key) internal pure returns (bytes memory abiEncodedData) {
         return vulcan.hevm.parseJson(jsonObj.serialized, key);
     }
 

--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -14,7 +14,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return abiEncodedData The ABI encoded tuple representing the value of the provided key.
-    function parseObject(string memory jsonStr, string memory key)
+    function get(string memory jsonStr, string memory key)
         internal
         pure
         returns (bytes memory abiEncodedData)
@@ -25,7 +25,7 @@ library json {
     /// @dev Parses a json object string and returns an ABI encoded tuple.
     /// @param jsonStr The json string.
     /// @return abiEncodedData The ABI encoded tuple representing the json object.
-    function parseObject(string memory jsonStr) internal pure returns (bytes memory abiEncodedData) {
+    function getObject(string memory jsonStr) internal pure returns (bytes memory abiEncodedData) {
         return vulcan.hevm.parseJson(jsonStr);
     }
 
@@ -33,7 +33,7 @@ library json {
     /// @param jsonObj The json object struct.
     /// @param key The key from the `jsonObject` to parse.
     /// @return abiEncodedData The ABI encoded tuple representing the value of the provided key.
-    function parseObject(JsonObject memory jsonObj, string memory key)
+    function getObject(JsonObject memory jsonObj, string memory key)
         internal
         pure
         returns (bytes memory abiEncodedData)
@@ -44,7 +44,7 @@ library json {
     /// @dev Parses a json object struct and returns an ABI encoded tuple.
     /// @param jsonObj The json struct.
     /// @return abiEncodedData The ABI encoded tuple representing the json object.
-    function parseObject(JsonObject memory jsonObj) internal pure returns (bytes memory abiEncodedData) {
+    function getObject(JsonObject memory jsonObj) internal pure returns (bytes memory abiEncodedData) {
         return vulcan.hevm.parseJson(jsonObj.serialized);
     }
 
@@ -52,7 +52,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The uint256 value.
-    function parseUint(string memory jsonStr, string memory key) internal returns (uint256) {
+    function getUint(string memory jsonStr, string memory key) internal returns (uint256) {
         return vulcan.hevm.parseJsonUint(jsonStr, key);
     }
 
@@ -60,7 +60,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The uint256[] value.
-    function parseUintArray(string memory jsonStr, string memory key) internal returns (uint256[] memory) {
+    function getUintArray(string memory jsonStr, string memory key) internal returns (uint256[] memory) {
         return vulcan.hevm.parseJsonUintArray(jsonStr, key);
     }
 
@@ -68,7 +68,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The int256 value.
-    function parseInt(string memory jsonStr, string memory key) internal returns (int256) {
+    function getInt(string memory jsonStr, string memory key) internal returns (int256) {
         return vulcan.hevm.parseJsonInt(jsonStr, key);
     }
 
@@ -76,7 +76,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The int256[] value.
-    function parseIntArray(string memory jsonStr, string memory key) internal returns (int256[] memory) {
+    function getIntArray(string memory jsonStr, string memory key) internal returns (int256[] memory) {
         return vulcan.hevm.parseJsonIntArray(jsonStr, key);
     }
 
@@ -84,7 +84,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The bool value.
-    function parseBool(string memory jsonStr, string memory key) internal returns (bool) {
+    function getBool(string memory jsonStr, string memory key) internal returns (bool) {
         return vulcan.hevm.parseJsonBool(jsonStr, key);
     }
 
@@ -92,7 +92,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The bool[] value.
-    function parseBoolArray(string memory jsonStr, string memory key) internal returns (bool[] memory) {
+    function getBoolArray(string memory jsonStr, string memory key) internal returns (bool[] memory) {
         return vulcan.hevm.parseJsonBoolArray(jsonStr, key);
     }
 
@@ -100,7 +100,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The address value.
-    function parseAddress(string memory jsonStr, string memory key) internal returns (address) {
+    function getAddress(string memory jsonStr, string memory key) internal returns (address) {
         return vulcan.hevm.parseJsonAddress(jsonStr, key);
     }
 
@@ -108,7 +108,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The address value.
-    function parseAddressArray(string memory jsonStr, string memory key) internal returns (address[] memory) {
+    function getAddressArray(string memory jsonStr, string memory key) internal returns (address[] memory) {
         return vulcan.hevm.parseJsonAddressArray(jsonStr, key);
     }
 
@@ -116,7 +116,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The string value.
-    function parseString(string memory jsonStr, string memory key) internal returns (string memory) {
+    function getString(string memory jsonStr, string memory key) internal returns (string memory) {
         return vulcan.hevm.parseJsonString(jsonStr, key);
     }
 
@@ -124,7 +124,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The string[] value.
-    function parseStringArray(string memory jsonStr, string memory key) internal returns (string[] memory) {
+    function getStringArray(string memory jsonStr, string memory key) internal returns (string[] memory) {
         return vulcan.hevm.parseJsonStringArray(jsonStr, key);
     }
 
@@ -132,7 +132,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The bytes value.
-    function parseBytes(string memory jsonStr, string memory key) internal returns (bytes memory) {
+    function getBytes(string memory jsonStr, string memory key) internal returns (bytes memory) {
         return vulcan.hevm.parseJsonBytes(jsonStr, key);
     }
 
@@ -140,7 +140,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The bytes[] value.
-    function parseBytesArray(string memory jsonStr, string memory key) internal returns (bytes[] memory) {
+    function getBytesArray(string memory jsonStr, string memory key) internal returns (bytes[] memory) {
         return vulcan.hevm.parseJsonBytesArray(jsonStr, key);
     }
 
@@ -148,7 +148,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The bytes32 value.
-    function parseBytes32(string memory jsonStr, string memory key) internal returns (bytes32) {
+    function getBytes32(string memory jsonStr, string memory key) internal returns (bytes32) {
         return vulcan.hevm.parseJsonBytes32(jsonStr, key);
     }
 
@@ -156,7 +156,7 @@ library json {
     /// @param jsonStr The json string.
     /// @param key The key from the `jsonStr` to parse.
     /// @return The bytes32[] value.
-    function parseBytes32Array(string memory jsonStr, string memory key) internal returns (bytes32[] memory) {
+    function getBytes32Array(string memory jsonStr, string memory key) internal returns (bytes32[] memory) {
         return vulcan.hevm.parseJsonBytes32Array(jsonStr, key);
     }
 

--- a/test/_modules/Json.t.sol
+++ b/test/_modules/Json.t.sol
@@ -9,15 +9,15 @@ contract JsonTest is Test {
         string foo;
     }
 
-    function testGet() external {
+    function testParse() external {
         string memory jsonStr = '{"foo":"bar"}';
-        Foo memory obj = abi.decode(json.get(jsonStr), (Foo));
+        Foo memory obj = abi.decode(json.parse(jsonStr), (Foo));
         expect(obj.foo).toEqual("bar");
     }
 
-    function testGetStruct() external {
+    function testParseStruct() external {
         JsonObject memory jsonObject = json.create().set("foo", string("bar"));
-        Foo memory obj = abi.decode(json.get(jsonObject), (Foo));
+        Foo memory obj = abi.decode(json.parse(jsonObject), (Foo));
         expect(obj.foo).toEqual("bar");
     }
 

--- a/test/_modules/Json.t.sol
+++ b/test/_modules/Json.t.sol
@@ -9,85 +9,85 @@ contract JsonTest is Test {
         string foo;
     }
 
-    function testParseObject() external {
+    function testGet() external {
         string memory jsonStr = '{"foo":"bar"}';
-        Foo memory obj = abi.decode(json.getObject(jsonStr), (Foo));
+        Foo memory obj = abi.decode(json.get(jsonStr), (Foo));
         expect(obj.foo).toEqual("bar");
     }
 
-    function testParseObjectStruct() external {
+    function testGetStruct() external {
         JsonObject memory jsonObject = json.create().set("foo", string("bar"));
-        Foo memory obj = abi.decode(json.getObject(jsonObject), (Foo));
+        Foo memory obj = abi.decode(json.get(jsonObject), (Foo));
         expect(obj.foo).toEqual("bar");
     }
 
-    function testParseUint() external {
+    function testGetUint() external {
         expect(json.getUint('{"foo":123}', ".foo")).toEqual(123);
     }
 
-    function testParseUintArray() external {
+    function testGetUintArray() external {
         uint256[] memory arr = json.getUintArray('{"foo":[123]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual(123);
     }
 
-    function testParseInt() external {
+    function testGetInt() external {
         expect(json.getInt('{"foo":-123}', ".foo")).toEqual(-123);
     }
 
-    function testParseIntArray() external {
+    function testGetIntArray() external {
         int256[] memory arr = json.getIntArray('{"foo":[-123]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual(-123);
     }
 
-    function testParseBool() external {
+    function testGetBool() external {
         expect(json.getBool('{"foo":true}', ".foo")).toEqual(true);
     }
 
-    function testParseBoolArray() external {
+    function testGetBoolArray() external {
         bool[] memory arr = json.getBoolArray('{"foo":[true]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual(true);
     }
 
-    function testParseAddress() external {
+    function testGetAddress() external {
         expect(json.getAddress('{"foo":"0x0000000000000000000000000000000000000001"}', ".foo")).toEqual(address(1));
     }
 
-    function testParseAddressArray() external {
+    function testGetAddressArray() external {
         address[] memory arr = json.getAddressArray('{"foo":["0x0000000000000000000000000000000000000001"]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual(address(1));
     }
 
-    function testParseString() external {
+    function testGetString() external {
         expect(json.getString('{"foo":"bar"}', ".foo")).toEqual("bar");
     }
 
-    function testParseStringArray() external {
+    function testGetStringArray() external {
         string[] memory arr = json.getStringArray('{"foo":["bar"]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual("bar");
     }
 
-    function testParseBytes() external {
+    function testGetBytes() external {
         expect(json.getBytes('{"foo":"0x1234"}', ".foo")).toEqual(hex"1234");
     }
 
-    function testParseBytesArray() external {
+    function testGetBytesArray() external {
         bytes[] memory arr = json.getBytesArray('{"foo":["0x1234"]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual(hex"1234");
     }
 
-    function testParseBytes32() external {
+    function testGetBytes32() external {
         expect(
             json.getBytes32('{"foo":"0x0000000000000000000000000000000000000000000000000000000000000001"}', ".foo")
         ).toEqual(bytes32(uint256(1)));
     }
 
-    function testParseBytes32Array() external {
+    function testGetBytes32Array() external {
         bytes32[] memory arr = json.getBytes32Array(
             '{"foo":["0x0000000000000000000000000000000000000000000000000000000000000001"]}', ".foo"
         );

--- a/test/_modules/Json.t.sol
+++ b/test/_modules/Json.t.sol
@@ -82,9 +82,8 @@ contract JsonTest is Test {
     }
 
     function testGetBytes32() external {
-        expect(
-            json.getBytes32('{"foo":"0x0000000000000000000000000000000000000000000000000000000000000001"}', ".foo")
-        ).toEqual(bytes32(uint256(1)));
+        expect(json.getBytes32('{"foo":"0x0000000000000000000000000000000000000000000000000000000000000001"}', ".foo"))
+            .toEqual(bytes32(uint256(1)));
     }
 
     function testGetBytes32Array() external {

--- a/test/_modules/Json.t.sol
+++ b/test/_modules/Json.t.sol
@@ -11,84 +11,84 @@ contract JsonTest is Test {
 
     function testParseObject() external {
         string memory jsonStr = '{"foo":"bar"}';
-        Foo memory obj = abi.decode(json.parseObject(jsonStr), (Foo));
+        Foo memory obj = abi.decode(json.getObject(jsonStr), (Foo));
         expect(obj.foo).toEqual("bar");
     }
 
     function testParseObjectStruct() external {
         JsonObject memory jsonObject = json.create().set("foo", string("bar"));
-        Foo memory obj = abi.decode(json.parseObject(jsonObject), (Foo));
+        Foo memory obj = abi.decode(json.getObject(jsonObject), (Foo));
         expect(obj.foo).toEqual("bar");
     }
 
     function testParseUint() external {
-        expect(json.parseUint('{"foo":123}', ".foo")).toEqual(123);
+        expect(json.getUint('{"foo":123}', ".foo")).toEqual(123);
     }
 
     function testParseUintArray() external {
-        uint256[] memory arr = json.parseUintArray('{"foo":[123]}', ".foo");
+        uint256[] memory arr = json.getUintArray('{"foo":[123]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual(123);
     }
 
     function testParseInt() external {
-        expect(json.parseInt('{"foo":-123}', ".foo")).toEqual(-123);
+        expect(json.getInt('{"foo":-123}', ".foo")).toEqual(-123);
     }
 
     function testParseIntArray() external {
-        int256[] memory arr = json.parseIntArray('{"foo":[-123]}', ".foo");
+        int256[] memory arr = json.getIntArray('{"foo":[-123]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual(-123);
     }
 
     function testParseBool() external {
-        expect(json.parseBool('{"foo":true}', ".foo")).toEqual(true);
+        expect(json.getBool('{"foo":true}', ".foo")).toEqual(true);
     }
 
     function testParseBoolArray() external {
-        bool[] memory arr = json.parseBoolArray('{"foo":[true]}', ".foo");
+        bool[] memory arr = json.getBoolArray('{"foo":[true]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual(true);
     }
 
     function testParseAddress() external {
-        expect(json.parseAddress('{"foo":"0x0000000000000000000000000000000000000001"}', ".foo")).toEqual(address(1));
+        expect(json.getAddress('{"foo":"0x0000000000000000000000000000000000000001"}', ".foo")).toEqual(address(1));
     }
 
     function testParseAddressArray() external {
-        address[] memory arr = json.parseAddressArray('{"foo":["0x0000000000000000000000000000000000000001"]}', ".foo");
+        address[] memory arr = json.getAddressArray('{"foo":["0x0000000000000000000000000000000000000001"]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual(address(1));
     }
 
     function testParseString() external {
-        expect(json.parseString('{"foo":"bar"}', ".foo")).toEqual("bar");
+        expect(json.getString('{"foo":"bar"}', ".foo")).toEqual("bar");
     }
 
     function testParseStringArray() external {
-        string[] memory arr = json.parseStringArray('{"foo":["bar"]}', ".foo");
+        string[] memory arr = json.getStringArray('{"foo":["bar"]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual("bar");
     }
 
     function testParseBytes() external {
-        expect(json.parseBytes('{"foo":"0x1234"}', ".foo")).toEqual(hex"1234");
+        expect(json.getBytes('{"foo":"0x1234"}', ".foo")).toEqual(hex"1234");
     }
 
     function testParseBytesArray() external {
-        bytes[] memory arr = json.parseBytesArray('{"foo":["0x1234"]}', ".foo");
+        bytes[] memory arr = json.getBytesArray('{"foo":["0x1234"]}', ".foo");
         expect(arr.length).toEqual(1);
         expect(arr[0]).toEqual(hex"1234");
     }
 
     function testParseBytes32() external {
         expect(
-            json.parseBytes32('{"foo":"0x0000000000000000000000000000000000000000000000000000000000000001"}', ".foo")
+            json.getBytes32('{"foo":"0x0000000000000000000000000000000000000000000000000000000000000001"}', ".foo")
         ).toEqual(bytes32(uint256(1)));
     }
 
     function testParseBytes32Array() external {
-        bytes32[] memory arr = json.parseBytes32Array(
+        bytes32[] memory arr = json.getBytes32Array(
             '{"foo":["0x0000000000000000000000000000000000000000000000000000000000000001"]}', ".foo"
         );
         expect(arr.length).toEqual(1);


### PR DESCRIPTION
This PR changes the name of the `parse*` functions on the `json` module to `get*`, for example `parseObject` is now `getObject`