### PR TITLE
fix: use try/catch on `stopPrank`

### DIFF
--- a/src/_modules/Accounts.sol
+++ b/src/_modules/Accounts.sol
@@ -228,7 +228,7 @@ library accounts {
 
     /// @notice Resets the values of `msg.sender` and `tx.origin` to the original values.
     function stopImpersonate() internal {
-        vulcan.hevm.stopPrank();
+        try vulcan.hevm.stopPrank() {} catch (bytes memory) {}
     }
 
     /// @dev Sets the balance of an address and returns the address that was modified.


### PR DESCRIPTION
Fixes a breaking change introduced on foundry that makes the `vm.stopPrank` fail if there is no active prank