### PR TITLE
Remove everything related to block difficulty

### DIFF
--- a/docs/src/modules/context.md
+++ b/docs/src/modules/context.md
@@ -13,7 +13,7 @@ import { Test, ctx } from "vulcan/test.sol";
 contract TestMyContract is Test {
     function testMyContract() external {
         // Update block state
-        ctx.setBlockTimestamp(123).setBlockNumber(456).setBlockDifficulty(789);
+        ctx.setBlockTimestamp(123).setBlockNumber(456);
 
         // Use snapshots
         uint256 snapshotId = ctx.snapshot();

--- a/docs/src/reference/modules/context.md
+++ b/docs/src/reference/modules/context.md
@@ -57,14 +57,6 @@ sets the `block.basefee` to `baseFee`
 
 sets the `block.basefee` to `baseFee`
 
-#### **`setBlockDifficulty(Context self, uint256 difficulty) → (Context)`**
-
-sets the `block.difficulty` to `difficulty`
-
-#### **`setBlockDifficulty(uint256 difficulty) → (Context)`**
-
-sets the `block.difficulty` to `difficulty`
-
 #### **`setChainId(Context self, uint64 chainId) → (Context)`**
 
 sets the `block.chainid` to `chainId`

--- a/src/_modules/Context.sol
+++ b/src/_modules/Context.sol
@@ -165,19 +165,6 @@ library ctx {
         return setBlockBaseFee(Context.wrap(0), baseFee);
     }
 
-    /// @dev sets the `block.difficulty` to `difficulty`
-    /// @param difficulty the new block difficulty
-    function setBlockDifficulty(Context self, uint256 difficulty) internal returns (Context) {
-        vulcan.hevm.difficulty(difficulty);
-        return self;
-    }
-
-    /// @dev sets the `block.difficulty` to `difficulty`
-    /// @param difficulty the new block difficulty
-    function setBlockDifficulty(uint256 difficulty) internal returns (Context) {
-        return setBlockDifficulty(Context.wrap(0), difficulty);
-    }
-
     /// @dev sets the `block.chainid` to `chainId`
     /// @param chainId the new block chain id
     function setChainId(Context self, uint64 chainId) internal returns (Context) {

--- a/test/ExampleTest.sol
+++ b/test/ExampleTest.sol
@@ -58,13 +58,6 @@ contract ExampleTest is Test {
         expect(block.basefee).toEqual(baseFee);
     }
 
-    function testSetBlockDifficulty() external {
-        uint256 difficulty = 1337;
-        ctx.setBlockDifficulty(difficulty);
-
-        expect(block.difficulty).toEqual(difficulty);
-    }
-
     function testSetChainId() external {
         uint64 chainId = 1337;
         ctx.setChainId(chainId);

--- a/test/_modules/Context.t.sol
+++ b/test/_modules/Context.t.sol
@@ -21,12 +21,6 @@ contract ContextTest is Test {
         expect(block.basefee).toEqual(baseFee);
     }
 
-    function testItCanSetTheBlockDifficulty(uint256 difficulty) external {
-        ctx.setBlockDifficulty(difficulty);
-
-        expect(block.difficulty).toEqual(difficulty);
-    }
-
     function testItCanSetTheChainId(uint64 chainId) external {
         ctx.setChainId(chainId);
 


### PR DESCRIPTION
With the last foundry update, setting and getting the block difficulty has been deprecated and doesn't work anymore: https://github.com/foundry-rs/foundry/pull/4856