### PR TITLE
Fix `setCode` test

### DIFF
--- a/test/_modules/Accounts.t.sol
+++ b/test/_modules/Accounts.t.sol
@@ -28,7 +28,7 @@ contract AccountsTest is Test {
     }
 
     function testItCanSetTheCode() external {
-        address addr = address(1);
+        address addr = address(1337);
 
         Sender sender = new Sender();
 


### PR DESCRIPTION
There was a change on foundry that prevents using `etch` on addresses < 10. The `setCode` test was using `address(1)` as the target so the test started to fail.

Solution: Use an address >= 10 to fix the test