### PR TITLE
fix: remove warnings

### DIFF
--- a/src/_modules/Fs.sol
+++ b/src/_modules/Fs.sol
@@ -38,7 +38,7 @@ library fs {
     /// @dev Obtains the metadata of the specified file or directory.
     /// @param fileOrDir The path to the file or directory.
     /// @return data The metadata of the file or directory.
-    function metadata(string memory fileOrDir) internal returns (FsMetadata memory data) {
+    function metadata(string memory fileOrDir) internal view returns (FsMetadata memory data) {
         Hevm.FsMetadata memory md = vulcan.hevm.fsMetadata(fileOrDir);
         assembly {
             data := md
@@ -103,7 +103,7 @@ library fs {
     /// @dev Checks if a file or directory exists.
     /// @param path The file or directory to check.
     /// @return Whether the file on `path` exists or not.
-    function fileExists(string memory path) internal returns (bool) {
+    function fileExists(string memory path) internal view returns (bool) {
         try vulcan.hevm.fsMetadata(path) {
             return true;
         } catch Error(string memory) {

--- a/src/_utils/println.sol
+++ b/src/_utils/println.sol
@@ -4,10 +4,10 @@ pragma solidity >=0.8.13 <0.9.0;
 import {console} from "../_modules/Console.sol";
 import {fmt} from "../_modules/Fmt.sol";
 
-function println(string memory template, bytes memory args) view {
+function println(string memory template, bytes memory args) pure {
     console.log(fmt.format(template, args));
 }
 
-function println(string memory arg) view {
+function println(string memory arg) pure {
     console.log(arg);
 }

--- a/test/ExampleTest.sol
+++ b/test/ExampleTest.sol
@@ -21,7 +21,7 @@ contract ExampleTest is Test {
         expect(false).toEqual(false);
     }
 
-    function testConsoleLog() external view {
+    function testConsoleLog() external pure {
         console.log("hello world");
     }
 


### PR DESCRIPTION
Remove warnings from:
- `Example.t.sol`
- `Fs.sol`
- `println.sol`