### PR TITLE
feat: add function to calculate deployment addresses

### DIFF
--- a/docs/src/reference/modules/accounts.md
+++ b/docs/src/reference/modules/accounts.md
@@ -48,6 +48,14 @@ Creates an address using the hash of the specified `name` as the private key and
 
 Creates an address using the hash of the specified `name` as the private key and adds a label to the address.
 
+#### **`getDeploymentAddress(address who, uint64 nonce) → (address)`**
+
+Calculates the deployment address of `who` with nonce `nonce`.
+
+#### **`getDeploymentAddress(address who) → (address)`**
+
+Calculates the deployment address of `who` with the current nonce.
+
 #### **`setStorage(address self, bytes32 slot, bytes32 value) → (address)`**
 
 Sets the specified `slot` in the storage of the given `self` address to the provided `value`.

--- a/src/_modules/Accounts.sol
+++ b/src/_modules/Accounts.sol
@@ -102,6 +102,43 @@ library accountsSafe {
 
         return label(addr, lbl);
     }
+
+    /// @dev Calculates the deployment address of `who` with nonce `nonce`.
+    /// @param who The deployer address.
+    /// @param nonce The deployer nonce.
+    function getDeploymentAddress(address who, uint64 nonce) internal pure returns (address) {
+        bytes memory data;
+
+        if (nonce == 0x00) {
+            data = abi.encodePacked(bytes1(0xd6), bytes1(0x94), who, bytes1(0x80));
+        } else if (nonce <= 0x7f) {
+            data = abi.encodePacked(bytes1(0xd6), bytes1(0x94), who, uint8(nonce));
+        } else if (nonce <= 0xff) {
+            data = abi.encodePacked(bytes1(0xd7), bytes1(0x94), who, bytes1(0x81), uint8(nonce));
+        } else if (nonce <= 0xffff) {
+            data = abi.encodePacked(bytes1(0xd8), bytes1(0x94), who, bytes1(0x82), uint16(nonce));
+        } else if (nonce <= 0xffffff) {
+            data = abi.encodePacked(bytes1(0xd9), bytes1(0x94), who, bytes1(0x83), uint24(nonce));
+        } else if (nonce <= 0xffffffff) {
+            data = abi.encodePacked(bytes1(0xda), bytes1(0x94), who, bytes1(0x84), uint32(nonce));
+        } else if (nonce <= 0xffffffffff) {
+            data = abi.encodePacked(bytes1(0xdb), bytes1(0x94), who, bytes1(0x85), uint40(nonce));
+        } else if (nonce <= 0xffffffffffff) {
+            data = abi.encodePacked(bytes1(0xdc), bytes1(0x94), who, bytes1(0x86), uint48(nonce));
+        } else if (nonce <= 0xffffffffffffff) {
+            data = abi.encodePacked(bytes1(0xdd), bytes1(0x94), who, bytes1(0x87), uint56(nonce));
+        } else if (nonce <= 0xffffffffffffffff) {
+            data = abi.encodePacked(bytes1(0xde), bytes1(0x94), who, bytes1(0x88), uint64(nonce));
+        }
+
+        return address(uint160(uint256(keccak256(data))));
+    }
+
+    /// @dev Calculates the deployment address of `who` with the current nonce.
+    /// @param who The deployer address.
+    function getDeploymentAddress(address who) internal view returns (address) {
+        return getDeploymentAddress(who, getNonce(who));
+    }
 }
 
 library accounts {
@@ -165,6 +202,14 @@ library accounts {
 
     function create(string memory name, string memory lbl) internal returns (address) {
         return accountsSafe.create(name, lbl);
+    }
+
+    function getDeploymentAddress(address who, uint64 nonce) internal pure returns (address) {
+        return accountsSafe.getDeploymentAddress(who, nonce);
+    }
+
+    function getDeploymentAddress(address who) internal view returns (address) {
+        return accountsSafe.getDeploymentAddress(who);
     }
 
     /// @dev Sets the specified `slot` in the storage of the given `self` address to the provided `value`.

--- a/src/_modules/Accounts.sol
+++ b/src/_modules/Accounts.sol
@@ -204,10 +204,15 @@ library accounts {
         return accountsSafe.create(name, lbl);
     }
 
+    /// @dev Calculates the deployment address of `who` with nonce `nonce`.
+    /// @param who The deployer address.
+    /// @param nonce The deployer nonce.
     function getDeploymentAddress(address who, uint64 nonce) internal pure returns (address) {
         return accountsSafe.getDeploymentAddress(who, nonce);
     }
 
+    /// @dev Calculates the deployment address of `who` with the current nonce.
+    /// @param who The deployer address.
     function getDeploymentAddress(address who) internal view returns (address) {
         return accountsSafe.getDeploymentAddress(who);
     }

--- a/test/_modules/Accounts.t.sol
+++ b/test/_modules/Accounts.t.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.8.13 <0.9.0;
 
-import {Test, expect, commands, accounts, console} from "../../src/test.sol";
+import {Test, expect, commands, accounts, console, ctx} from "../../src/test.sol";
 import {Sender} from "../mocks/Sender.sol";
 
 contract AccountsTest is Test {
@@ -201,6 +201,32 @@ contract AccountsTest is Test {
 
         expect(token.balanceOf(user)).toEqual(balance - firstBurn - secondBurn);
         expect(token.totalSupply()).toEqual(totalSupply - firstBurn - secondBurn);
+    }
+
+    function testGetDeploymentAddressWithCurrentNonce(address user, uint64 nonce) external {
+        ctx.assume(nonce < type(uint64).max);
+
+        address deploymentAddress = user.setNonce(uint64(nonce)).getDeploymentAddress();
+
+        user.impersonateOnce();
+
+        address deployedAddress = address(new TestToken());
+
+        expect(deployedAddress).toEqual(deploymentAddress);
+    }
+
+    function testGetDeploymentAddress(address user, uint64 nonce) external {
+        ctx.assume(nonce < type(uint64).max);
+
+        address deploymentAddress = user.getDeploymentAddress(nonce);
+
+        user.setNonce(nonce);
+
+        user.impersonateOnce();
+
+        address deployedAddress = address(new TestToken());
+
+        expect(deployedAddress).toEqual(deploymentAddress);
     }
 }
 


### PR DESCRIPTION
Adds `getDeploymentAddress` to the `addresses module` to calculate the deployment address of contracts without deploying them.