### PR TITLE
feat: add method to create multiple addresses

### DIFF
--- a/src/_modules/Accounts.sol
+++ b/src/_modules/Accounts.sol
@@ -156,7 +156,7 @@ library accountsSafe {
 
     /// @dev Generates an array of addresses with a specific length.
     /// @param length The amount of addresses to generate.
-    function generateAddresses(uint256 length) internal returns (address[] memory) {
+    function createMany(uint256 length) internal returns (address[] memory) {
         require(length > 0, "accounts: invalid length for addresses array");
 
         address[] memory addresses = new address[](length);
@@ -412,7 +412,7 @@ library accounts {
 
     /// @dev Generates an array of addresses with a specific length.
     /// @param length The amount of addresses to generate.
-    function generateAddresses(uint256 length) internal returns (address[] memory) {
-        return accountsSafe.generateAddresses(length);
+    function createMany(uint256 length) internal returns (address[] memory) {
+        return accountsSafe.createMany(length);
     }
 }

--- a/test/_modules/Accounts.t.sol
+++ b/test/_modules/Accounts.t.sol
@@ -228,6 +228,25 @@ contract AccountsTest is Test {
 
         expect(deployedAddress).toEqual(deploymentAddress);
     }
+
+    function testCreateAddresWithoutName() external {
+        address first = accounts.create();
+        address second = accounts.create();
+
+        expect(first).not.toEqual(second);
+    }
+
+    function testCreateAddressesArray() external {
+        uint256 length = 20;
+
+        address[] memory addresses = accounts.generateAddresses(length);
+
+        expect(addresses.length).toEqual(length);
+
+        for (uint256 i; i < length; i++) {
+            expect(addresses[i]).toEqual(accounts.derive(uint256(keccak256(abi.encode(i)))));
+        }
+    }
 }
 
 contract TestToken {

--- a/test/_modules/Accounts.t.sol
+++ b/test/_modules/Accounts.t.sol
@@ -239,7 +239,7 @@ contract AccountsTest is Test {
     function testCreateAddressesArray() external {
         uint256 length = 20;
 
-        address[] memory addresses = accounts.generateAddresses(length);
+        address[] memory addresses = accounts.createMany(length);
 
         expect(addresses.length).toEqual(length);
 


### PR DESCRIPTION
Adds a method to the accounts module to create an array of addresses.

Closes #127 