### PR TITLE
chore: update unwrap error format

### DIFF
--- a/src/_modules/Commands.sol
+++ b/src/_modules/Commands.sol
@@ -280,7 +280,7 @@ library commands {
             error = string.concat("Failed to run command ", self.command.toString());
 
             if (self.stderr.length > 0) {
-                error = string.concat(error, ": ", string(self.stderr));
+                error = string.concat(error, ":\n\n", string(self.stderr));
             }
         }
 

--- a/test/_modules/Commands.t.sol
+++ b/test/_modules/Commands.t.sol
@@ -68,7 +68,7 @@ contract CommandsTest is Test {
 
         bytes memory expectedError = bytes(
             string.concat(
-                "Failed to run command forge --hlkfshjfhjas: ",
+                "Failed to run command forge --hlkfshjfhjas:\n\n",
                 "error: unexpected argument '--hlkfshjfhjas' found\n\n",
                 "Usage: forge <COMMAND>\n\n" "For more information, try '--help'.\n"
             )


### PR DESCRIPTION
Updates the format of the error message when using `command.unwrap`