### PR TITLE
feat: adds createMay(length, prefix)

### DIFF
--- a/src/_modules/Accounts.sol
+++ b/src/_modules/Accounts.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.13 <0.9.0;
 
 import {stdStorage, StdStorage} from "forge-std/StdStorage.sol";
 
+import {strings} from "./Strings.sol";
 import "./Vulcan.sol";
 
 library accountsSafe {
@@ -155,6 +156,22 @@ library accountsSafe {
 
         for (uint256 i; i < length; i++) {
             addresses[i] = create();
+        }
+
+        return addresses;
+    }
+
+    /// @dev Generates an array of addresses with a specific length and a prefix as label.
+    /// The label for each address will be `{prefix}_{i}`.
+    /// @param length The amount of addresses to generate.
+    /// @param prefix The prefix of the label for each address.
+    function createMany(uint256 length, string memory prefix) internal returns (address[] memory) {
+        require(length > 0, "accounts: invalid length for addresses array");
+
+        address[] memory addresses = new address[](length);
+
+        for (uint256 i; i < length; i++) {
+            addresses[i] = create(string.concat(prefix, "_", strings.toString(i)));
         }
 
         return addresses;


### PR DESCRIPTION
Adds a new function to the `accounts` module `createMany(length, prefix)` that creates an array of addresses of a specified length and applies a label to each one with a prefix `prefix` in the form of `{prefix}_{i}`.

Resolves #129 