### PR TITLE
chore: add `rawConsoleLog` function

### DIFF
--- a/src/_utils/println.sol
+++ b/src/_utils/println.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13 <0.9.0;
 
-import {console} from "../_modules/Console.sol";
 import {fmt} from "../_modules/Fmt.sol";
+import {rawConsoleLog} from "./rawConsole.sol";
 
-function println(string memory template, bytes memory args) pure {
-    console.log(fmt.format(template, args));
+function println(string memory template, bytes memory args) view {
+    rawConsoleLog(fmt.format(template, args));
 }
 
-function println(string memory arg) pure {
-    console.log(arg);
+function println(string memory arg) view {
+    rawConsoleLog(arg);
 }

--- a/src/_utils/rawConsole.sol
+++ b/src/_utils/rawConsole.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13 <0.9.0;
+
+function rawConsoleLog(string memory arg) view {
+    address console2Addr = 0x000000000000000000636F6e736F6c652e6c6f67;
+    (bool status,) = console2Addr.staticcall(abi.encodeWithSignature("log(string)", arg));
+    status;
+}

--- a/test/ExampleTest.sol
+++ b/test/ExampleTest.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.8.13 <0.9.0;
 
-import {Test, expect, accounts, ctx, console, vulcan, accounts} from "../src/test.sol";
+import {Test, expect, accounts, ctx, vulcan, accounts, println} from "../src/test.sol";
 import {Sender} from "./mocks/Sender.sol";
 
 contract ExampleTest is Test {
@@ -21,8 +21,8 @@ contract ExampleTest is Test {
         expect(false).toEqual(false);
     }
 
-    function testConsoleLog() external pure {
-        console.log("hello world");
+    function testConsoleLog() external view {
+        println("hello world");
     }
 
     function testGetNonce() external {

--- a/test/_modules/Forks.t.sol
+++ b/test/_modules/Forks.t.sol
@@ -1,6 +1,7 @@
 pragma solidity >=0.8.13 <0.9.0;
 
-import {Test, expect, commands, forks, Fork, console, CommandResult} from "../../src/test.sol";
+import {Test, expect, commands, forks, Fork, CommandResult} from "../../src/test.sol";
+import {rawConsoleLog} from "../../src/_utils/rawConsole.sol";
 import {Sender} from "../mocks/Sender.sol";
 
 contract ForksTest is Test {
@@ -14,7 +15,7 @@ contract ForksTest is Test {
         ).run();
 
         if (res.stdout.length == 0) {
-            console.log("Skipping test because forking endpoint is not available");
+            rawConsoleLog("Skipping test because forking endpoint is not available");
             return;
         }
 

--- a/test/_modules/Forks.t.sol
+++ b/test/_modules/Forks.t.sol
@@ -1,7 +1,6 @@
 pragma solidity >=0.8.13 <0.9.0;
 
-import {Test, expect, commands, forks, Fork, CommandResult} from "../../src/test.sol";
-import {rawConsoleLog} from "../../src/_utils/rawConsole.sol";
+import {Test, expect, commands, forks, Fork, CommandResult, println} from "../../src/test.sol";
 import {Sender} from "../mocks/Sender.sol";
 
 contract ForksTest is Test {
@@ -15,7 +14,7 @@ contract ForksTest is Test {
         ).run();
 
         if (res.stdout.length == 0) {
-            rawConsoleLog("Skipping test because forking endpoint is not available");
+            println("Skipping test because forking endpoint is not available");
             return;
         }
 


### PR DESCRIPTION
Add a `rawConsoleLog` function to prevent compiling the whole `console` contract from `forge-std`.

Resolves #120