### PR TITLE
chore: add formatError function

### DIFF
--- a/src/_modules/Accounts.sol
+++ b/src/_modules/Accounts.sol
@@ -5,6 +5,7 @@ import {stdStorage, StdStorage} from "forge-std/StdStorage.sol";
 
 import {strings} from "./Strings.sol";
 import "./Vulcan.sol";
+import {formatError} from "../_utils/formatError.sol";
 
 library accountsSafe {
     /// @dev Reads the storage at the specified `slot` for the given `who` address and returns the content.
@@ -150,7 +151,7 @@ library accountsSafe {
     /// @dev Generates an array of addresses with a specific length.
     /// @param length The amount of addresses to generate.
     function createMany(uint256 length) internal returns (address[] memory) {
-        require(length > 0, "accounts: invalid length for addresses array");
+        require(length > 0, _formatError("createMany(uint256)", "Invalid length for addresses array"));
 
         address[] memory addresses = new address[](length);
 
@@ -184,6 +185,10 @@ library accountsSafe {
             count := sload(slot)
             sstore(slot, add(count, 1))
         }
+    }
+
+    function _formatError(string memory func, string memory message) private pure returns (string memory) {
+        return formatError("accounts", func, message);
     }
 }
 

--- a/src/_modules/Context.sol
+++ b/src/_modules/Context.sol
@@ -5,6 +5,7 @@ import "./Vulcan.sol";
 import "./Accounts.sol";
 import "./Strings.sol";
 import "../_utils/println.sol";
+import {formatError} from "../_utils/formatError.sol";
 
 type Context is bytes32;
 
@@ -74,7 +75,7 @@ library ctxSafe {
 
     function startGasReport(string memory name) internal {
         if (bytes(name).length > 32) {
-            revert("ctx.startGasReport: Gas report name can't have more than 32 characters");
+            revert(_formatError("startGasReport", "Gas report name can't have more than 32 characters"));
         }
 
         bytes32 b32Name = bytes32(bytes(name));
@@ -91,9 +92,13 @@ library ctxSafe {
         bytes32 valueSlot = keccak256(abi.encodePacked("vulcan.ctx.gasReport", b32Name));
         uint256 prevGas = uint256(accounts.readStorage(address(vulcan.hevm), valueSlot));
         if (gas > prevGas) {
-            revert("ctx.endGasReport: Gas used can't have a negative value");
+            revert(_formatError("endGasReport", "Gas used can't have a negative value"));
         }
         println(string.concat("gas(", string(abi.encodePacked(b32Name)), "):", strings.toString(prevGas - gas)));
+    }
+
+    function _formatError(string memory func, string memory message) private pure returns (string memory) {
+        return formatError("ctx", func, message);
     }
 }
 

--- a/src/_modules/Fe.sol
+++ b/src/_modules/Fe.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.13 <0.9.0;
 import "./Commands.sol";
 import "./Strings.sol";
 import "./Fs.sol";
+import {formatError} from "../_utils/formatError.sol";
 
 struct Fe {
     string compilerPath;
@@ -83,10 +84,14 @@ library fe {
         string memory path = string.concat(self.outputDir, "/", contractName, "/", contractName, ".bin");
 
         if (!fs.fileExists(path)) {
-            revert("Contract not found");
+            revert(_formatError("getBytecode(Fe,string))", "Contract not found"));
         }
 
         return fs.readFileBinary(path);
+    }
+
+    function _formatError(string memory func, string memory message) private pure returns (string memory) {
+        return formatError("fe", func, message);
     }
 }
 

--- a/src/_modules/Fmt.sol
+++ b/src/_modules/Fmt.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.13 <0.9.0;
 
 import "./Strings.sol";
+import {formatError} from "../_utils/formatError.sol";
 
 enum Type {
     Bool,
@@ -151,7 +152,7 @@ library fmt {
             return new bytes(0);
         }
 
-        require(start + len <= data.length, "Slice out of bounds");
+        require(start + len <= data.length, _formatError("_readSlice(bytes,uint256,uint256)", "Slice out of bounds"));
 
         bytes memory result = new bytes(len);
 
@@ -265,5 +266,9 @@ library fmt {
         }
 
         return string(result);
+    }
+
+    function _formatError(string memory func, string memory message) private pure returns (string memory) {
+        return formatError("fmt", func, message);
     }
 }

--- a/src/_modules/Fmt.sol
+++ b/src/_modules/Fmt.sol
@@ -128,7 +128,7 @@ library fmt {
         } else if (typeHash == BYTES32_HASH || typeHash == ABBREVIATED_BYTES32_HASH) {
             t = Type.Bytes32;
         } else {
-            revert("Unsupported placeholder type");
+            revert(_formatError("_findPlaceholder(bytes,uint256)", "Unsupported placeholder type"));
         }
 
         bytes memory mod = modifierStart == placeholderEnd
@@ -189,7 +189,7 @@ library fmt {
                 uint256 len = uint256(_readWord(data, offset));
                 value = string(_readSlice(data, offset + 32, len));
             } else {
-                revert("Unsupported type");
+                revert(_formatError("_decodeArgs(Placeholder[],bytes)", "Unsupported type"));
             }
             result[i] = value;
         }
@@ -226,7 +226,7 @@ library fmt {
 
             return string.concat(integer, ".", remainder);
         } else {
-            revert("Unsupported modifier");
+            revert(_formatError("_display(uint256,bytes)", "Unsupported modifier"));
         }
     }
 

--- a/src/_modules/Gas.sol
+++ b/src/_modules/Gas.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.17;
 
 import "./Vulcan.sol";
 import "./Accounts.sol";
+import {formatError} from "../_utils/formatError.sol";
 
 library gas {
     bytes32 constant GAS_MEASUREMENTS_MAGIC = keccak256("vulcan.gas.measurements.magic");
@@ -19,7 +20,7 @@ library gas {
         uint256 startGas = uint256(accounts.readStorage(address(vulcan.hevm), startSlot));
 
         if (endGas > startGas) {
-            revert("gas.stopRecord: Gas used can't have a negative value");
+            revert(_formatError("stopRecord", "Gas used can't have a negative value"));
         }
 
         bytes32 endSlot = keccak256(abi.encode(GAS_MEASUREMENTS_MAGIC, name, "end"));
@@ -42,5 +43,9 @@ library gas {
         (uint256 startGas, uint256 endGas) = getRecord(name);
 
         return startGas - endGas;
+    }
+
+    function _formatError(string memory func, string memory message) private pure returns (string memory) {
+        return formatError("gas", func, message);
     }
 }

--- a/src/_modules/Huff.sol
+++ b/src/_modules/Huff.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.13 <0.9.0;
 
 import "./Commands.sol";
 import "./Strings.sol";
+import {formatError} from "../_utils/formatError.sol";
 
 struct Huffc {
     string compilerPath;
@@ -37,7 +38,7 @@ library huff {
 
     function toCommand(Huffc memory self) internal pure returns (Command memory) {
         Command memory command = commands.create(self.compilerPath);
-        require(bytes(self.filePath).length > 0, "self.filePath not set");
+        require(bytes(self.filePath).length > 0, _formatError("toCommand(Huffc)", "self.filePath not set"));
 
         if (bytes(self.outputPath).length > 0) command = command.args(["-ao", self.outputPath]);
         if (bytes(self.mainName).length > 0) command = command.args(["-m", self.mainName]);
@@ -102,5 +103,9 @@ library huff {
         overrides[overrides.length - 1] = string.concat(const, "=", value.toString());
         self.constantOverrides = overrides;
         return self;
+    }
+
+    function _formatError(string memory func, string memory message) private pure returns (string memory) {
+        return formatError("huff", func, message);
     }
 }

--- a/src/_modules/Watchers.sol
+++ b/src/_modules/Watchers.sol
@@ -5,6 +5,7 @@ import "./Vulcan.sol";
 import "./Events.sol";
 import "./Accounts.sol";
 import "./Context.sol";
+import {formatError} from "../_utils/formatError.sol";
 
 struct Call {
     bytes callData;
@@ -38,7 +39,7 @@ library watchers {
     /// @return The Watcher implementation.
     function watcher(address target) internal view returns (Watcher) {
         address _watcher = watcherAddress(target);
-        require(_watcher.code.length != 0, "Address doesn't have a watcher");
+        require(_watcher.code.length != 0, _formatError("watcher(address)", "Address doesn't have a watcher"));
 
         return Watcher(_watcher);
     }
@@ -48,7 +49,7 @@ library watchers {
     /// @return The Watcher implementation.
     function watch(address target) internal returns (Watcher) {
         address _watcher = watcherAddress(target);
-        require(_watcher.code.length == 0, "Address already has a watcher");
+        require(_watcher.code.length == 0, _formatError("watch(address)", "Address already has a watcher"));
 
         accounts.setCode(_watcher, type(Watcher).runtimeCode);
 
@@ -124,6 +125,10 @@ library watchers {
         Watcher _watcher = watcher(target);
         _watcher.disableCaptureReverts();
         return _watcher;
+    }
+
+    function _formatError(string memory func, string memory message) private pure returns (string memory){
+        return formatError("watchers", func, message);
     }
 }
 
@@ -279,4 +284,5 @@ contract WatcherProxy {
 
         return returnData;
     }
+
 }

--- a/src/_modules/Watchers.sol
+++ b/src/_modules/Watchers.sol
@@ -127,7 +127,7 @@ library watchers {
         return _watcher;
     }
 
-    function _formatError(string memory func, string memory message) private pure returns (string memory){
+    function _formatError(string memory func, string memory message) private pure returns (string memory) {
         return formatError("watchers", func, message);
     }
 }
@@ -284,5 +284,4 @@ contract WatcherProxy {
 
         return returnData;
     }
-
 }

--- a/src/_utils/bound.sol
+++ b/src/_utils/bound.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13 <0.9.0;
 
+import {formatError} from "./formatError.sol";
+
 // Extracted from forge-std stdUtils: https://github.com/foundry-rs/forge-std/blob/7b4876e8de2a232a54159035f173e35421000c19/src/StdUtils.sol
 // The main difference is that we use file-level functions instead of an abstract contract.
 
@@ -8,7 +10,7 @@ uint256 constant UINT256_MAX = type(uint256).max;
 uint256 constant INT256_MIN_ABS = uint256(type(int256).max) + 1;
 
 function bound(uint256 x, uint256 min, uint256 max) pure returns (uint256 result) {
-    require(min <= max, "Vulcan bound(uint256,uint256,uint256): Max is less than min.");
+    require(min <= max, formatError("_utils", "bound(uint256,uint256,uint256)",  "Max is less than min."));
     // If x is between min and max, return x directly. This is to ensure that dictionary values
     // do not get shifted if the min is nonzero. More info: https://github.com/foundry-rs/forge-std/issues/188
     if (x >= min && x <= max) return x;
@@ -35,7 +37,7 @@ function bound(uint256 x, uint256 min, uint256 max) pure returns (uint256 result
 }
 
 function bound(int256 x, int256 min, int256 max) pure returns (int256 result) {
-    require(min <= max, "Vulcan bound(int256,int256,int256): Max is less than min.");
+    require(min <= max, formatError("_utils", "bound(int256,int256,int256)",  "Max is less than min."));
 
     // Shifting all int256 values to uint256 to use _bound function. The range of two types are:
     // int256 : -(2**255) ~ (2**255 - 1)

--- a/src/_utils/bound.sol
+++ b/src/_utils/bound.sol
@@ -10,7 +10,7 @@ uint256 constant UINT256_MAX = type(uint256).max;
 uint256 constant INT256_MIN_ABS = uint256(type(int256).max) + 1;
 
 function bound(uint256 x, uint256 min, uint256 max) pure returns (uint256 result) {
-    require(min <= max, formatError("_utils", "bound(uint256,uint256,uint256)",  "Max is less than min."));
+    require(min <= max, formatError("_utils", "bound(uint256,uint256,uint256)", "Max is less than min."));
     // If x is between min and max, return x directly. This is to ensure that dictionary values
     // do not get shifted if the min is nonzero. More info: https://github.com/foundry-rs/forge-std/issues/188
     if (x >= min && x <= max) return x;
@@ -37,7 +37,7 @@ function bound(uint256 x, uint256 min, uint256 max) pure returns (uint256 result
 }
 
 function bound(int256 x, int256 min, int256 max) pure returns (int256 result) {
-    require(min <= max, formatError("_utils", "bound(int256,int256,int256)",  "Max is less than min."));
+    require(min <= max, formatError("_utils", "bound(int256,int256,int256)", "Max is less than min."));
 
     // Shifting all int256 values to uint256 to use _bound function. The range of two types are:
     // int256 : -(2**255) ~ (2**255 - 1)

--- a/src/_utils/formatError.sol
+++ b/src/_utils/formatError.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13 <0.9.0;
+
+function formatError(string memory module, string memory func, string memory message) pure returns (string memory) {
+    return string.concat("vulcan.", module, ".", func, ": ", message);
+}

--- a/src/test.sol
+++ b/src/test.sol
@@ -24,6 +24,7 @@ import {fe, Fe} from "./_modules/Fe.sol";
 import {format} from "./_utils/format.sol";
 import {println} from "./_utils/println.sol";
 import {bound} from "./_utils/bound.sol";
+import {formatError} from "./_utils/formatError.sol";
 
 // @dev Main entry point to Vulcan tests
 contract Test is InvariantsBase {
@@ -47,7 +48,7 @@ contract Test is InvariantsBase {
         }
 
         if (!post) {
-            revert("Vulcan shouldFail: Didn't fail");
+            revert(formatError("test", "shouldFail()", "Test expected to fail"));
         }
 
         vulcan.clearFailure();


### PR DESCRIPTION
add `formatError` function to standardize Vulcan error messages.

Resolves #105 