### PR TITLE
Update Request.sol: Optimized 'for' loops

### DIFF
--- a/src/_modules/experimental/Request.sol
+++ b/src/_modules/experimental/Request.sol
@@ -217,7 +217,7 @@ library LibRequestBuilder {
             Request memory req = self.request.toValue();
             uint256 len = req.headers.length;
             req.headers = new Header[](len + 1);
-            for (uint256 i = 0; i < len; i++) {
+            for (uint256 i; i < len; i++) {
                 req.headers[i] = req.headers[i];
             }
             req.headers[len] = Header({key: key, value: value});
@@ -242,7 +242,7 @@ library LibRequest {
         string memory script =
             string.concat('response=$(curl -s -w "\\n%{http_code}" ', self.url, " -X ", toString(self.method));
 
-        for (uint256 i = 0; i < self.headers.length; i++) {
+        for (uint256 i; i < self.headers.length; i++) {
             script = string.concat(script, " -H ", '"', self.headers[i].key, ": ", self.headers[i].value, '"');
         }
 


### PR DESCRIPTION
Change made in this PR is -> `uint256 i = 0;` to `uint256 i;`

Usually default value of any `uint` is 0, so it is kind of wastage of some gas in initializing some 'uint' variable to 0

Well, two more changes can be made in these for loops, which will really optimize the gas usage in this smart contract:

1. Let's take a look at this code snippet:
```
for (uint256 i; i < len; i++) {
    req.headers[i] = req.headers[i];
}
```
Here, as far I am concerned, 'len' will never be part of any 'integer overflow', and 'i++' used to perform two operations in this code snippet which are -> first it iterates the value of i, and also it checks whether i get 'overflowed' or not (and this check do costs some gas)
So it is kind of unfair when we know that this 'i' will never ever get overflowed because it will always be less than 'len' (which is always limited to a value less than 2**256 - 1)
Thus it be better, if we change this snippet to:
```
for (uint256 i; i < len;) {
    req.headers[i] = req.headers[i];
    unchecked{
        i++;
    }
}
```

2. Another change that can be made in this PR is: changing `i++` to `++i`, Actually '++i' takes costs less gas as compared to 'i++', and this change can easily be implemented here, if it doesn't mess up with the code's logic

After making these two changes, we can get our for loop as:
```
for (uint256 i; i < len;) {
    req.headers[i] = req.headers[i];
    unchecked{
        ++i;
    }
}
```

I haven't included these two changes in this PR, just need some approvals if you find these changes worth it..

Thanks!