### PR TITLE
refactor: remove result type

### DIFF
--- a/src/_modules/Commands.sol
+++ b/src/_modules/Commands.sol
@@ -3,7 +3,8 @@ pragma solidity >=0.8.13 <0.9.0;
 
 import {VmSafe} from "forge-std/Vm.sol";
 import {vulcan} from "./Vulcan.sol";
-import {Result, ResultType, Ok} from "./Result.sol";
+import {Pointer} from "./Pointer.sol";
+import {ResultType, LibResultPointer} from "./Result.sol";
 import {LibError, Error} from "./Error.sol";
 import {removeSelector} from "../_utils/removeSelector.sol";
 
@@ -414,21 +415,23 @@ library CommandError {
     }
 
     function toCommandResult(Error self) internal pure returns (CommandResult) {
-        return CommandResult.wrap(Result.unwrap(self.toResult()));
+        return CommandResult.wrap(Pointer.unwrap(self.toPointer()));
     }
 }
 
 library LibCommandResult {
+    using LibResultPointer for Pointer;
+
     function isOk(CommandResult self) internal pure returns (bool) {
-        return self.asResult().isOk();
+        return self.asPointer().isOk();
     }
 
     function isError(CommandResult self) internal pure returns (bool) {
-        return self.asResult().isError();
+        return self.asPointer().isError();
     }
 
     function unwrap(CommandResult self) internal pure returns (CommandOutput memory val) {
-        bytes32 _val = self.asResult().unwrap();
+        bytes32 _val = self.asPointer().unwrap();
         assembly {
             val := _val
         }
@@ -443,18 +446,18 @@ library LibCommandResult {
     }
 
     function toError(CommandResult self) internal pure returns (Error) {
-        return self.asResult().toError();
+        return self.asPointer().toError();
     }
 
     function toValue(CommandResult self) internal pure returns (CommandOutput memory val) {
-        bytes32 _val = self.asResult().toValue();
+        bytes32 _val = self.asPointer().toValue();
         assembly {
             val := _val
         }
     }
 
-    function asResult(CommandResult self) internal pure returns (Result) {
-        return Result.wrap(CommandResult.unwrap(self));
+    function asPointer(CommandResult self) internal pure returns (Pointer) {
+        return Pointer.wrap(CommandResult.unwrap(self));
     }
 }
 
@@ -463,7 +466,7 @@ function Ok(CommandOutput memory value) pure returns (CommandResult) {
     assembly {
         _value := value
     }
-    return CommandResult.wrap(Result.unwrap(Ok(_value)));
+    return CommandResult.wrap(Pointer.unwrap(ResultType.Ok.encode(_value)));
 }
 
 using commands for Command global;

--- a/src/_modules/Commands.sol
+++ b/src/_modules/Commands.sol
@@ -433,32 +433,32 @@ library LibCommandResult {
     using LibCommandOutputPointer for Pointer;
 
     function isOk(CommandResult self) internal pure returns (bool) {
-        return LibResultPointer.isOk(self.asPointer());
+        return LibResultPointer.isOk(self.toPointer());
     }
 
     function isError(CommandResult self) internal pure returns (bool) {
-        return LibResultPointer.isError(self.asPointer());
+        return LibResultPointer.isError(self.toPointer());
     }
 
     function unwrap(CommandResult self) internal pure returns (CommandOutput memory) {
-        return LibResultPointer.unwrap(self.asPointer()).asCommandOutput();
+        return LibResultPointer.unwrap(self.toPointer()).asCommandOutput();
     }
 
     function expect(CommandResult self, string memory err) internal pure returns (CommandOutput memory) {
-        return LibResultPointer.expect(self.asPointer(), err).asCommandOutput();
+        return LibResultPointer.expect(self.toPointer(), err).asCommandOutput();
     }
 
     function toError(CommandResult self) internal pure returns (Error) {
-        return LibResultPointer.toError(self.asPointer());
+        return LibResultPointer.toError(self.toPointer());
     }
 
     function toValue(CommandResult self) internal pure returns (CommandOutput memory) {
-        (, Pointer ptr) = LibResultPointer.decode(self.asPointer());
+        (, Pointer ptr) = LibResultPointer.decode(self.toPointer());
 
         return ptr.asCommandOutput();
     }
 
-    function asPointer(CommandResult self) internal pure returns (Pointer) {
+    function toPointer(CommandResult self) internal pure returns (Pointer) {
         return Pointer.wrap(CommandResult.unwrap(self));
     }
 }

--- a/src/_modules/Error.sol
+++ b/src/_modules/Error.sol
@@ -10,7 +10,7 @@ library LibError {
     using LibError for *;
 
     function toPointer(Error err) internal pure returns (Pointer) {
-        return LibResultPointer.encode(ResultType.Error, Error.unwrap(err));
+        return ResultType.Error.encode(Error.unwrap(err));
     }
 
     // Used internally by error functions

--- a/src/_modules/Error.sol
+++ b/src/_modules/Error.sol
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {LibResult, Result, ResultType} from "./Result.sol";
+import {Pointer} from "./Pointer.sol";
+import {LibResultPointer, ResultType} from "./Result.sol";
 
 type Error is bytes32;
 
 library LibError {
     using LibError for *;
 
-    function toResult(Error err) internal pure returns (Result) {
-        return LibResult.encode(ResultType.Error, Error.unwrap(err));
+    function toPointer(Error err) internal pure returns (Pointer) {
+        return LibResultPointer.encode(ResultType.Error, Error.unwrap(err));
     }
 
     // Used internally by error functions

--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -30,42 +30,43 @@ library JsonError {
     }
 }
 
+library LibJsonObjectPointer {
+    function asJsonObject(Pointer self) internal pure returns (JsonObject memory obj) {
+        bytes32 memoryAddr = self.asBytes32();
+
+        assembly {
+            obj := memoryAddr
+        }
+    }
+}
+
 library LibJsonResult {
-    using LibResultPointer for Pointer;
+    using LibJsonObjectPointer for Pointer;
 
     function isOk(JsonResult self) internal pure returns (bool) {
-        return self.asPointer().isOk();
+        return LibResultPointer.isOk(self.asPointer());
     }
 
     function isError(JsonResult self) internal pure returns (bool) {
-        return self.asPointer().isError();
+        return LibResultPointer.isError(self.asPointer());
     }
 
     function unwrap(JsonResult self) internal pure returns (JsonObject memory val) {
-        bytes32 _val = self.asPointer().unwrap();
-        assembly {
-            val := _val
-        }
+        return LibResultPointer.unwrap(self.asPointer()).asJsonObject();
     }
 
     function expect(JsonResult self, string memory err) internal pure returns (JsonObject memory) {
-        if (self.isError()) {
-            revert(err);
-        }
-
-        return self.toValue();
+        return LibResultPointer.expect(self.asPointer(), err).asJsonObject();
     }
 
     function toError(JsonResult self) internal pure returns (Error) {
-        return self.asPointer().toError();
+        return LibResultPointer.toError(self.asPointer());
     }
 
     function toValue(JsonResult self) internal pure returns (JsonObject memory val) {
-        bytes32 _val = self.asPointer().toValue();
+        (, Pointer ptr) = LibResultPointer.decode(self.asPointer());
 
-        assembly {
-            val := _val
-        }
+        return ptr.asJsonObject();
     }
 
     function asPointer(JsonResult self) internal pure returns (Pointer) {

--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13 <0.9.0;
 
-import {Result, LibResult, Ok} from "./Result.sol";
+import {Pointer} from "./Pointer.sol";
+import {ResultType, LibResultPointer} from "./Result.sol";
 import {LibError, Error} from "./Error.sol";
 import "./Accounts.sol";
 import "./Vulcan.sol";
@@ -25,21 +26,23 @@ library JsonError {
     }
 
     function toJsonResult(Error self) internal pure returns (JsonResult) {
-        return JsonResult.wrap(Result.unwrap(self.toResult()));
+        return JsonResult.wrap(Pointer.unwrap(self.toPointer()));
     }
 }
 
 library LibJsonResult {
+    using LibResultPointer for Pointer;
+
     function isOk(JsonResult self) internal pure returns (bool) {
-        return self.asResult().isOk();
+        return self.asPointer().isOk();
     }
 
     function isError(JsonResult self) internal pure returns (bool) {
-        return self.asResult().isError();
+        return self.asPointer().isError();
     }
 
     function unwrap(JsonResult self) internal pure returns (JsonObject memory val) {
-        bytes32 _val = self.asResult().unwrap();
+        bytes32 _val = self.asPointer().unwrap();
         assembly {
             val := _val
         }
@@ -54,19 +57,19 @@ library LibJsonResult {
     }
 
     function toError(JsonResult self) internal pure returns (Error) {
-        return self.asResult().toError();
+        return self.asPointer().toError();
     }
 
     function toValue(JsonResult self) internal pure returns (JsonObject memory val) {
-        bytes32 _val = self.asResult().toValue();
+        bytes32 _val = self.asPointer().toValue();
 
         assembly {
             val := _val
         }
     }
 
-    function asResult(JsonResult self) internal pure returns (Result) {
-        return Result.wrap(JsonResult.unwrap(self));
+    function asPointer(JsonResult self) internal pure returns (Pointer) {
+        return Pointer.wrap(JsonResult.unwrap(self));
     }
 }
 
@@ -75,7 +78,7 @@ function Ok(JsonObject memory value) pure returns (JsonResult) {
     assembly {
         _value := value
     }
-    return JsonResult.wrap(Result.unwrap(Ok(_value)));
+    return JsonResult.wrap(Pointer.unwrap(ResultType.Ok.encode(_value)));
 }
 
 library json {

--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -44,32 +44,32 @@ library LibJsonResult {
     using LibJsonObjectPointer for Pointer;
 
     function isOk(JsonResult self) internal pure returns (bool) {
-        return LibResultPointer.isOk(self.asPointer());
+        return LibResultPointer.isOk(self.toPointer());
     }
 
     function isError(JsonResult self) internal pure returns (bool) {
-        return LibResultPointer.isError(self.asPointer());
+        return LibResultPointer.isError(self.toPointer());
     }
 
     function unwrap(JsonResult self) internal pure returns (JsonObject memory val) {
-        return LibResultPointer.unwrap(self.asPointer()).asJsonObject();
+        return LibResultPointer.unwrap(self.toPointer()).asJsonObject();
     }
 
     function expect(JsonResult self, string memory err) internal pure returns (JsonObject memory) {
-        return LibResultPointer.expect(self.asPointer(), err).asJsonObject();
+        return LibResultPointer.expect(self.toPointer(), err).asJsonObject();
     }
 
     function toError(JsonResult self) internal pure returns (Error) {
-        return LibResultPointer.toError(self.asPointer());
+        return LibResultPointer.toError(self.toPointer());
     }
 
     function toValue(JsonResult self) internal pure returns (JsonObject memory val) {
-        (, Pointer ptr) = LibResultPointer.decode(self.asPointer());
+        (, Pointer ptr) = LibResultPointer.decode(self.toPointer());
 
         return ptr.asJsonObject();
     }
 
-    function asPointer(JsonResult self) internal pure returns (Pointer) {
+    function toPointer(JsonResult self) internal pure returns (Pointer) {
         return Pointer.wrap(JsonResult.unwrap(self));
     }
 }

--- a/src/_modules/Pointer.sol
+++ b/src/_modules/Pointer.sol
@@ -2,3 +2,43 @@
 pragma solidity >=0.8.13 <0.9.0;
 
 type Pointer is bytes32;
+
+library LibPointer {
+    function asBytes32(Pointer self) internal pure returns (bytes32) {
+        return Pointer.unwrap(self);
+    }
+
+    function asString(Pointer self) internal pure returns (string memory val) {
+        bytes32 memoryAddr = self.asBytes32();
+
+        assembly {
+            val := memoryAddr
+        }
+    }
+
+    function asBytes(Pointer self) internal pure returns (bytes memory val) {
+        bytes32 memoryAddr = self.asBytes32();
+
+        assembly {
+            val := memoryAddr
+        }
+    }
+
+    function asBool(Pointer self) internal pure returns (bool val) {
+        bytes32 memoryAddr = self.asBytes32();
+
+        assembly {
+            val := memoryAddr
+        }
+    }
+
+    function asUint256(Pointer self) internal pure returns (uint256 val) {
+        bytes32 memoryAddr = self.asBytes32();
+
+        assembly {
+            val := memoryAddr
+        }
+    }
+}
+
+using LibPointer for Pointer global;

--- a/src/_modules/Pointer.sol
+++ b/src/_modules/Pointer.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13 <0.9.0;
+
+type Pointer is bytes32;

--- a/src/_modules/Result.sol
+++ b/src/_modules/Result.sol
@@ -197,7 +197,6 @@ library LibResultType {
     }
 }
 
-
 function Ok(bytes32 value) pure returns (Bytes32Result) {
     return Bytes32Result.wrap(Pointer.unwrap(ResultType.Ok.encode(value)));
 }

--- a/src/_modules/Result.sol
+++ b/src/_modules/Result.sol
@@ -16,14 +16,6 @@ type BytesResult is bytes32;
 type StringResult is bytes32;
 
 library LibResultPointer {
-    function encode(ResultType _type, bytes32 _data) internal pure returns (Pointer pointer) {
-        bytes memory data = abi.encode(_type, _data);
-
-        assembly {
-            pointer := data
-        }
-    }
-
     function decode(Pointer self) internal pure returns (ResultType, Pointer) {
         bytes memory data;
         assembly {
@@ -87,7 +79,7 @@ library LibBytes32Result {
     }
 
     function toValue(Bytes32Result self) internal pure returns (bytes32) {
-        (, Pointer ptr) = LibResultPointer.decode(self.asPointer());
+        (, Pointer ptr) = LibResultPointer.decode(self.toPointer());
 
         return ptr.asBytes32();
     }
@@ -100,58 +92,58 @@ library LibBytes32Result {
         return LibResultPointer.expect(Pointer.wrap(Bytes32Result.unwrap(self)), err).asBytes32();
     }
 
-    function asPointer(Bytes32Result self) internal pure returns (Pointer) {
+    function toPointer(Bytes32Result self) internal pure returns (Pointer) {
         return Pointer.wrap(Bytes32Result.unwrap(self));
     }
 }
 
 library LibBytesResult {
     function isOk(BytesResult self) internal pure returns (bool) {
-        return LibResultPointer.isOk(self.asPointer());
+        return LibResultPointer.isOk(self.toPointer());
     }
 
     function isError(BytesResult self) internal pure returns (bool) {
-        return LibResultPointer.isError(self.asPointer());
+        return LibResultPointer.isError(self.toPointer());
     }
 
     function unwrap(BytesResult self) internal pure returns (bytes memory) {
-        return LibResultPointer.unwrap(self.asPointer()).asBytes();
+        return LibResultPointer.unwrap(self.toPointer()).asBytes();
     }
 
     function expect(BytesResult self, string memory err) internal pure returns (bytes memory) {
-        return LibResultPointer.expect(self.asPointer(), err).asBytes();
+        return LibResultPointer.expect(self.toPointer(), err).asBytes();
     }
 
     function toError(BytesResult self) internal pure returns (Error) {
-        return LibResultPointer.toError(self.asPointer());
+        return LibResultPointer.toError(self.toPointer());
     }
 
     function toValue(BytesResult self) internal pure returns (bytes memory) {
-        (, Pointer ptr) = LibResultPointer.decode(self.asPointer());
+        (, Pointer ptr) = LibResultPointer.decode(self.toPointer());
 
         return ptr.asBytes();
     }
 
-    function asPointer(BytesResult self) internal pure returns (Pointer) {
+    function toPointer(BytesResult self) internal pure returns (Pointer) {
         return Pointer.wrap(BytesResult.unwrap(self));
     }
 }
 
 library LibStringResult {
     function isOk(StringResult self) internal pure returns (bool) {
-        return LibResultPointer.isOk(self.asPointer());
+        return LibResultPointer.isOk(self.toPointer());
     }
 
     function isError(StringResult self) internal pure returns (bool) {
-        return LibResultPointer.isError(self.asPointer());
+        return LibResultPointer.isError(self.toPointer());
     }
 
     function unwrap(StringResult self) internal pure returns (string memory val) {
-        return LibResultPointer.unwrap(self.asPointer()).asString();
+        return LibResultPointer.unwrap(self.toPointer()).asString();
     }
 
     function expect(StringResult self, string memory err) internal pure returns (string memory) {
-        return LibResultPointer.expect(self.asPointer(), err).asString();
+        return LibResultPointer.expect(self.toPointer(), err).asString();
     }
 
     function toError(StringResult self) internal pure returns (Error) {
@@ -159,12 +151,12 @@ library LibStringResult {
     }
 
     function toValue(StringResult self) internal pure returns (string memory val) {
-        (, Pointer ptr) = LibResultPointer.decode(self.asPointer());
+        (, Pointer ptr) = LibResultPointer.decode(self.toPointer());
 
         return ptr.asString();
     }
 
-    function asPointer(StringResult self) internal pure returns (Pointer) {
+    function toPointer(StringResult self) internal pure returns (Pointer) {
         return Pointer.wrap(StringResult.unwrap(self));
     }
 }

--- a/src/_modules/experimental/Request.sol
+++ b/src/_modules/experimental/Request.sol
@@ -102,7 +102,7 @@ library LibRequestResult {
     }
 
     function expect(RequestResult self, string memory err) internal pure returns (Request memory) {
-        return LibResultPointer.expect(self.asPointer() ,err).asRequest();
+        return LibResultPointer.expect(self.asPointer(), err).asRequest();
     }
 
     function toError(RequestResult self) internal pure returns (Error) {

--- a/src/_modules/experimental/Request.sol
+++ b/src/_modules/experimental/Request.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.13;
 import {Command, CommandResult, CommandOutput, commands} from "../Commands.sol";
 import {JsonObject, json as jsonModule, JsonResult, Ok} from "../Json.sol";
 
-import {Result, BytesResult, StringResult, Ok} from "../Result.sol";
+import {Pointer} from "../Pointer.sol";
+import {BytesResult, StringResult, Ok, ResultType, LibResultPointer} from "../Result.sol";
 import {LibError, Error} from "../Error.sol";
 
 enum Method {
@@ -67,25 +68,27 @@ library RequestError {
     }
 
     function toRequestResult(Error self) internal pure returns (RequestResult) {
-        return RequestResult.wrap(Result.unwrap(self.toResult()));
+        return RequestResult.wrap(Pointer.unwrap(self.toPointer()));
     }
 
     function toResponseResult(Error self) internal pure returns (ResponseResult) {
-        return ResponseResult.wrap(Result.unwrap(self.toResult()));
+        return ResponseResult.wrap(Pointer.unwrap(self.toPointer()));
     }
 }
 
 library LibRequestResult {
+    using LibResultPointer for Pointer;
+
     function isOk(RequestResult self) internal pure returns (bool) {
-        return self.asResult().isOk();
+        return self.asPointer().isOk();
     }
 
     function isError(RequestResult self) internal pure returns (bool) {
-        return self.asResult().isError();
+        return self.asPointer().isError();
     }
 
     function unwrap(RequestResult self) internal pure returns (Request memory val) {
-        bytes32 _val = self.asResult().unwrap();
+        bytes32 _val = self.asPointer().unwrap();
         assembly {
             val := _val
         }
@@ -100,32 +103,34 @@ library LibRequestResult {
     }
 
     function toError(RequestResult self) internal pure returns (Error) {
-        return self.asResult().toError();
+        return self.asPointer().toError();
     }
 
     function toValue(RequestResult self) internal pure returns (Request memory val) {
-        bytes32 _val = self.asResult().toValue();
+        bytes32 _val = self.asPointer().toValue();
         assembly {
             val := _val
         }
     }
 
-    function asResult(RequestResult self) internal pure returns (Result) {
-        return Result.wrap(RequestResult.unwrap(self));
+    function asPointer(RequestResult self) internal pure returns (Pointer) {
+        return Pointer.wrap(RequestResult.unwrap(self));
     }
 }
 
 library LibResponseResult {
+    using LibResultPointer for Pointer;
+
     function isOk(ResponseResult self) internal pure returns (bool) {
-        return self.asResult().isOk();
+        return self.asPointer().isOk();
     }
 
     function isError(ResponseResult self) internal pure returns (bool) {
-        return self.asResult().isError();
+        return self.asPointer().isError();
     }
 
     function unwrap(ResponseResult self) internal pure returns (Response memory val) {
-        bytes32 _val = self.asResult().unwrap();
+        bytes32 _val = self.asPointer().unwrap();
         assembly {
             val := _val
         }
@@ -140,18 +145,18 @@ library LibResponseResult {
     }
 
     function toError(ResponseResult self) internal pure returns (Error) {
-        return self.asResult().toError();
+        return self.asPointer().toError();
     }
 
     function toValue(ResponseResult self) internal pure returns (Response memory val) {
-        bytes32 _val = self.asResult().toValue();
+        bytes32 _val = self.asPointer().toValue();
         assembly {
             val := _val
         }
     }
 
-    function asResult(ResponseResult self) internal pure returns (Result) {
-        return Result.wrap(ResponseResult.unwrap(self));
+    function asPointer(ResponseResult self) internal pure returns (Pointer) {
+        return Pointer.wrap(ResponseResult.unwrap(self));
     }
 }
 
@@ -347,7 +352,7 @@ function Ok(Request memory value) pure returns (RequestResult) {
     assembly {
         _value := value
     }
-    return RequestResult.wrap(Result.unwrap(Ok(_value)));
+    return RequestResult.wrap(Pointer.unwrap(ResultType.Ok.encode(_value)));
 }
 
 function Ok(Response memory value) pure returns (ResponseResult) {
@@ -355,7 +360,7 @@ function Ok(Response memory value) pure returns (ResponseResult) {
     assembly {
         _value := value
     }
-    return ResponseResult.wrap(Result.unwrap(Ok(_value)));
+    return ResponseResult.wrap(Pointer.unwrap(ResultType.Ok.encode(_value)));
 }
 
 using LibRequestClient for RequestClient global;

--- a/src/_modules/experimental/Request.sol
+++ b/src/_modules/experimental/Request.sol
@@ -76,41 +76,43 @@ library RequestError {
     }
 }
 
+library LibRequestPointer {
+    function asRequest(Pointer self) internal pure returns (Request memory req) {
+        bytes32 memoryAddr = self.asBytes32();
+
+        assembly {
+            req := memoryAddr
+        }
+    }
+}
+
 library LibRequestResult {
-    using LibResultPointer for Pointer;
+    using LibRequestPointer for Pointer;
 
     function isOk(RequestResult self) internal pure returns (bool) {
-        return self.asPointer().isOk();
+        return LibResultPointer.isOk(self.asPointer());
     }
 
     function isError(RequestResult self) internal pure returns (bool) {
-        return self.asPointer().isError();
+        return LibResultPointer.isError(self.asPointer());
     }
 
     function unwrap(RequestResult self) internal pure returns (Request memory val) {
-        bytes32 _val = self.asPointer().unwrap();
-        assembly {
-            val := _val
-        }
+        return LibResultPointer.unwrap(self.asPointer()).asRequest();
     }
 
     function expect(RequestResult self, string memory err) internal pure returns (Request memory) {
-        if (self.isError()) {
-            revert(err);
-        }
-
-        return self.toValue();
+        return LibResultPointer.expect(self.asPointer() ,err).asRequest();
     }
 
     function toError(RequestResult self) internal pure returns (Error) {
-        return self.asPointer().toError();
+        return LibResultPointer.toError(self.asPointer());
     }
 
     function toValue(RequestResult self) internal pure returns (Request memory val) {
-        bytes32 _val = self.asPointer().toValue();
-        assembly {
-            val := _val
-        }
+        (, Pointer ptr) = LibResultPointer.decode(self.asPointer());
+
+        return ptr.asRequest();
     }
 
     function asPointer(RequestResult self) internal pure returns (Pointer) {
@@ -118,41 +120,43 @@ library LibRequestResult {
     }
 }
 
+library LibResponsePointer {
+    function asResponse(Pointer self) internal pure returns (Response memory res) {
+        bytes32 memoryAddr = self.asBytes32();
+
+        assembly {
+            res := memoryAddr
+        }
+    }
+}
+
 library LibResponseResult {
-    using LibResultPointer for Pointer;
+    using LibResponsePointer for Pointer;
 
     function isOk(ResponseResult self) internal pure returns (bool) {
-        return self.asPointer().isOk();
+        return LibResultPointer.isOk(self.asPointer());
     }
 
     function isError(ResponseResult self) internal pure returns (bool) {
-        return self.asPointer().isError();
+        return LibResultPointer.isError(self.asPointer());
     }
 
     function unwrap(ResponseResult self) internal pure returns (Response memory val) {
-        bytes32 _val = self.asPointer().unwrap();
-        assembly {
-            val := _val
-        }
+        return LibResultPointer.unwrap(self.asPointer()).asResponse();
     }
 
     function expect(ResponseResult self, string memory err) internal pure returns (Response memory) {
-        if (self.isError()) {
-            revert(err);
-        }
-
-        return self.toValue();
+        return LibResultPointer.expect(self.asPointer(), err).asResponse();
     }
 
     function toError(ResponseResult self) internal pure returns (Error) {
-        return self.asPointer().toError();
+        return LibResultPointer.toError(self.asPointer());
     }
 
     function toValue(ResponseResult self) internal pure returns (Response memory val) {
-        bytes32 _val = self.asPointer().toValue();
-        assembly {
-            val := _val
-        }
+        (, Pointer ptr) = LibResultPointer.decode(self.asPointer());
+
+        return ptr.asResponse();
     }
 
     function asPointer(ResponseResult self) internal pure returns (Pointer) {

--- a/src/_modules/experimental/Request.sol
+++ b/src/_modules/experimental/Request.sol
@@ -90,32 +90,32 @@ library LibRequestResult {
     using LibRequestPointer for Pointer;
 
     function isOk(RequestResult self) internal pure returns (bool) {
-        return LibResultPointer.isOk(self.asPointer());
+        return LibResultPointer.isOk(self.toPointer());
     }
 
     function isError(RequestResult self) internal pure returns (bool) {
-        return LibResultPointer.isError(self.asPointer());
+        return LibResultPointer.isError(self.toPointer());
     }
 
     function unwrap(RequestResult self) internal pure returns (Request memory val) {
-        return LibResultPointer.unwrap(self.asPointer()).asRequest();
+        return LibResultPointer.unwrap(self.toPointer()).asRequest();
     }
 
     function expect(RequestResult self, string memory err) internal pure returns (Request memory) {
-        return LibResultPointer.expect(self.asPointer(), err).asRequest();
+        return LibResultPointer.expect(self.toPointer(), err).asRequest();
     }
 
     function toError(RequestResult self) internal pure returns (Error) {
-        return LibResultPointer.toError(self.asPointer());
+        return LibResultPointer.toError(self.toPointer());
     }
 
     function toValue(RequestResult self) internal pure returns (Request memory val) {
-        (, Pointer ptr) = LibResultPointer.decode(self.asPointer());
+        (, Pointer ptr) = LibResultPointer.decode(self.toPointer());
 
         return ptr.asRequest();
     }
 
-    function asPointer(RequestResult self) internal pure returns (Pointer) {
+    function toPointer(RequestResult self) internal pure returns (Pointer) {
         return Pointer.wrap(RequestResult.unwrap(self));
     }
 }
@@ -134,32 +134,32 @@ library LibResponseResult {
     using LibResponsePointer for Pointer;
 
     function isOk(ResponseResult self) internal pure returns (bool) {
-        return LibResultPointer.isOk(self.asPointer());
+        return LibResultPointer.isOk(self.toPointer());
     }
 
     function isError(ResponseResult self) internal pure returns (bool) {
-        return LibResultPointer.isError(self.asPointer());
+        return LibResultPointer.isError(self.toPointer());
     }
 
     function unwrap(ResponseResult self) internal pure returns (Response memory val) {
-        return LibResultPointer.unwrap(self.asPointer()).asResponse();
+        return LibResultPointer.unwrap(self.toPointer()).asResponse();
     }
 
     function expect(ResponseResult self, string memory err) internal pure returns (Response memory) {
-        return LibResultPointer.expect(self.asPointer(), err).asResponse();
+        return LibResultPointer.expect(self.toPointer(), err).asResponse();
     }
 
     function toError(ResponseResult self) internal pure returns (Error) {
-        return LibResultPointer.toError(self.asPointer());
+        return LibResultPointer.toError(self.toPointer());
     }
 
     function toValue(ResponseResult self) internal pure returns (Response memory val) {
-        (, Pointer ptr) = LibResultPointer.decode(self.asPointer());
+        (, Pointer ptr) = LibResultPointer.decode(self.toPointer());
 
         return ptr.asResponse();
     }
 
-    function asPointer(ResponseResult self) internal pure returns (Pointer) {
+    function toPointer(ResponseResult self) internal pure returns (Pointer) {
         return Pointer.wrap(ResponseResult.unwrap(self));
     }
 }

--- a/test/_modules/Pointer.t.sol
+++ b/test/_modules/Pointer.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13 <0.9.0;
+
+import {Pointer} from "../../src/_modules/Pointer.sol";
+import {Test, expect} from "../../src/test.sol";
+
+contract PointerTest is Test {
+    function testAsBytes32(bytes32 value) external {
+        Pointer ptr;
+
+        assembly {
+            ptr := value
+        }
+
+        expect(ptr.asBytes32()).toEqual(value);
+    }
+
+    function testAsString(string memory value) external {
+        Pointer ptr;
+
+        assembly {
+            ptr := value
+        }
+
+        expect(ptr.asString()).toEqual(value);
+    }
+}


### PR DESCRIPTION
This PR removes the `Result` type and uses a `Pointer` type instead.

Also creates a `Bytes32Result` type.