### PR TITLE
feat: use `serializeJson` cheatcode

### DIFF
--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -240,7 +240,7 @@ library json {
         }
 
         JsonObject memory jsonObj = create();
-        jsonObj.serialized = vulcan.hevm.serializeJson("", obj);
+        jsonObj.serialized = vulcan.hevm.serializeJson(jsonObj.id, obj);
 
         return Ok(jsonObj);
     }

--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -21,10 +21,6 @@ library JsonError {
         return Invalid.encodeError("Invalid json");
     }
 
-    function Immutable() internal pure returns (Error) {
-        return Immutable.encodeError("Json object is immutable");
-    }
-
     function toJsonResult(Error self) internal pure returns (JsonResult) {
         return JsonResult.wrap(Pointer.unwrap(self.toPointer()));
     }
@@ -238,12 +234,15 @@ library json {
 
     /// @dev Creates a new JsonObject struct.
     /// @return The JsonObject struct.
-    function create(string memory obj) internal pure returns (JsonResult) {
+    function create(string memory obj) internal returns (JsonResult) {
         if (!isValid(obj)) {
             return JsonError.Invalid().toJsonResult();
         }
 
-        return Ok(JsonObject({id: "", serialized: obj}));
+        JsonObject memory jsonObj = create();
+        jsonObj.serialized = vulcan.hevm.serializeJson("", obj);
+
+        return Ok(jsonObj);
     }
 
     /// @dev Serializes and sets the key and value for the provided json object.
@@ -439,10 +438,6 @@ library json {
     /// @param path The path where the file will be saved.
     function write(JsonObject memory obj, string memory path, string memory key) internal {
         vulcan.hevm.writeJson(obj.serialized, path, key);
-    }
-
-    function isImmutable(JsonObject memory obj) internal pure returns (bool) {
-        return bytes(obj.id).length == 0;
     }
 
     function _incrementId() private returns (uint256 count) {

--- a/src/_modules/experimental/Request.sol
+++ b/src/_modules/experimental/Request.sol
@@ -280,7 +280,7 @@ library LibRequestBuilder {
         return self.header("Content-Type", "application/json").body(obj.serialized);
     }
 
-    function json(RequestBuilder memory self, string memory serialized) internal pure returns (RequestBuilder memory) {
+    function json(RequestBuilder memory self, string memory serialized) internal returns (RequestBuilder memory) {
         if (self.request.isError()) {
             return self;
         }
@@ -336,7 +336,7 @@ library LibRequest {
 }
 
 library LibResponse {
-    function json(Response memory self) internal pure returns (JsonResult) {
+    function json(Response memory self) internal returns (JsonResult) {
         // create() will validate the json
         return jsonModule.create(string(self.body));
     }


### PR DESCRIPTION
- Use the new `serializeJson` cheatcode on the json module so we can remove the `"immutable"` json objects.
- Remove error and check related to immutable json objects.

Closes #193