### PR TITLE
fix: use forge@v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Over time, Vulcan will grow to include more functionality and utilities, eventua
 ## Installation
 
 ```
-$ forge install nomoixyz/vulcan@v0.4.0
+$ forge install nomoixyz/vulcan@v0.4.1
 ```
 
 ## Usage

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -2,5 +2,5 @@
 
 In an existing Foundry project, use `forge install`:
 ```
-$ forge install nomoixyz/vulcan@0.4.0
+$ forge install nomoixyz/vulcan@0.4.1
 ```

--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -7,6 +7,12 @@ import {LibError, Error} from "./Error.sol";
 import "./Accounts.sol";
 import "./Vulcan.sol";
 
+/// Hacky interface to use the `serializeJson` vm cheatcode
+/// TODO: remove
+interface SerializeJson {
+    function serializeJson(string memory, string memory) external returns (string memory);
+}
+
 struct JsonObject {
     string id;
     string serialized;
@@ -251,8 +257,10 @@ library json {
             return JsonError.Invalid().toJsonResult();
         }
 
+        // TODO: remove hack to use the unreleased `serializeJson` Vm cheatcode 
+        SerializeJson vm = SerializeJson(address(vulcan.hevm));
         JsonObject memory jsonObj = create();
-        jsonObj.serialized = vulcan.hevm.serializeJson(jsonObj.id, obj);
+        jsonObj.serialized = vm.serializeJson(jsonObj.id, obj);
 
         return Ok(jsonObj);
     }

--- a/src/_modules/Json.sol
+++ b/src/_modules/Json.sol
@@ -257,7 +257,7 @@ library json {
             return JsonError.Invalid().toJsonResult();
         }
 
-        // TODO: remove hack to use the unreleased `serializeJson` Vm cheatcode 
+        // TODO: remove hack to use the unreleased `serializeJson` Vm cheatcode
         SerializeJson vm = SerializeJson(address(vulcan.hevm));
         JsonObject memory jsonObj = create();
         jsonObj.serialized = vm.serializeJson(jsonObj.id, obj);


### PR DESCRIPTION
We were using a commit when installing `forge-std` as a dependency for vulcan. This is a problem because when you create a new forge project it comest with a tagged version installed that doesn't have all the cheatcodes that the commit could have. This means that if a user creates a new forge project and then installs vulcan on top the compilation will fail since the tagged version might not have the cheatcodes that we are using

To fix this:
1) Use the latest forge-std tagged release
2) Create interfaces to access new cheatcodes that are not yet released on that tag but that were included in foundry 