### PR TITLE
feat: add missing method aliases to requests

### DIFF
--- a/docs/src/examples/requests/example.md
+++ b/docs/src/examples/requests/example.md
@@ -11,11 +11,20 @@ import {Test, expect, request, Response} from "vulcan/test.sol";
 
 contract RequestExample is Test {
     function test() external {
-        Response memory getResponse = request.create().get("https://httpbin.org/get").send().unwrap();
-        Response memory postResponse = request.create().post("https://httpbin.org/post").send().unwrap();
-        Response memory patchResponse = request.create().patch("https://httpbin.org/patch").send().unwrap();
-        Response memory putResponse = request.create().put("https://httpbin.org/put").send().unwrap();
-        Response memory deleteResponse = request.create().del("https://httpbin.org/delete").send().unwrap();
+        // Alias to `request.create().get(url).send()`
+        Response memory getResponse = request.get("https://httpbin.org/get").unwrap();
+
+        // Alias to `request.create().post(url).send()`
+        Response memory postResponse = request.post("https://httpbin.org/post").unwrap();
+
+        // Alias to `request.create().patch(url).send()`
+        Response memory patchResponse = request.patch("https://httpbin.org/patch").unwrap();
+
+        // Alias to `request.create().put(url).send()`
+        Response memory putResponse = request.put("https://httpbin.org/put").unwrap();
+
+        // Alias to `request.create().del(url).send()`
+        Response memory deleteResponse = request.del("https://httpbin.org/delete").unwrap();
 
         expect(getResponse.status).toEqual(200);
         expect(postResponse.status).toEqual(200);

--- a/src/_modules/Request.sol
+++ b/src/_modules/Request.sol
@@ -68,8 +68,29 @@ library request {
         return LibHeaders.create();
     }
 
+    /// @dev Alias to `request.create().get(url).send()`
     function get(string memory url) internal returns (ResponseResult) {
         return create().get(url).send();
+    }
+
+    /// @dev Alias to `request.create().post(url).send()`
+    function post(string memory url) internal returns (ResponseResult) {
+        return create().post(url).send();
+    }
+
+    /// @dev Alias to `request.create().put(url).send()`
+    function put(string memory url) internal returns (ResponseResult) {
+        return create().put(url).send();
+    }
+
+    /// @dev Alias to `request.create().patch(url).send()`
+    function patch(string memory url) internal returns (ResponseResult) {
+        return create().patch(url).send();
+    }
+
+    /// @dev Alias to `request.create().del(url).send()`
+    function del(string memory url) internal returns (ResponseResult) {
+        return create().del(url).send();
     }
 }
 

--- a/test/examples/requests/RequestsExample01.t.sol
+++ b/test/examples/requests/RequestsExample01.t.sol
@@ -7,11 +7,20 @@ import {Test, expect, request, Response} from "vulcan/test.sol";
 /// @dev How to send requests to an http server
 contract RequestExample is Test {
     function test() external {
-        Response memory getResponse = request.create().get("https://httpbin.org/get").send().unwrap();
-        Response memory postResponse = request.create().post("https://httpbin.org/post").send().unwrap();
-        Response memory patchResponse = request.create().patch("https://httpbin.org/patch").send().unwrap();
-        Response memory putResponse = request.create().put("https://httpbin.org/put").send().unwrap();
-        Response memory deleteResponse = request.create().del("https://httpbin.org/delete").send().unwrap();
+        // Alias to `request.create().get(url).send()`
+        Response memory getResponse = request.get("https://httpbin.org/get").unwrap();
+
+        // Alias to `request.create().post(url).send()`
+        Response memory postResponse = request.post("https://httpbin.org/post").unwrap();
+
+        // Alias to `request.create().patch(url).send()`
+        Response memory patchResponse = request.patch("https://httpbin.org/patch").unwrap();
+
+        // Alias to `request.create().put(url).send()`
+        Response memory putResponse = request.put("https://httpbin.org/put").unwrap();
+
+        // Alias to `request.create().del(url).send()`
+        Response memory deleteResponse = request.del("https://httpbin.org/delete").unwrap();
 
         expect(getResponse.status).toEqual(200);
         expect(postResponse.status).toEqual(200);


### PR DESCRIPTION
Adds missing aliases to `request`
- `request.post(url)`
- `request.put(url)`
- `request.patch(url)`
- `request.del(url)`