### PR TITLE
Corrected install command in installation.md

### DIFF
--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -2,5 +2,5 @@
 
 In an existing Foundry project, use `forge install`:
 ```
-$ forge install nomoixyz/vulcan@0.4.2
+$ forge install nomoixyz/vulcan@v0.4.2
 ```


### PR DESCRIPTION
The installation refers to a tag that doesn't exist (0.4.2), the tag should be v0.4.2