### PR TITLE
Fix installation instruction in docs

### DIFF
--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -2,5 +2,5 @@
 
 In an existing Foundry project, use `forge install`:
 ```
-$ forge install nomoixyz/vulcan@0.4.2
+$ forge install nomoixyz/vulcan@v0.4.2
 ```


### PR DESCRIPTION
There is a mistake in the installation instructions. It says the following command is required to install Vulcan:
```sh
forge install nomoixyz/vulcan@0.4.2
```
However, the actual command is:
```sh
forge install nomoixyz/vulcan@v0.4.2
```